### PR TITLE
Fix/addCuratedComplexRulesToModel

### DIFF
--- a/ComplementaryScripts/GPRs/EnzymeComplexes/addCuratedComplexRulesToModel.m
+++ b/ComplementaryScripts/GPRs/EnzymeComplexes/addCuratedComplexRulesToModel.m
@@ -51,6 +51,7 @@ function model_new = addCuratedComplexRulesToModel(model,curationFile,delRedunda
 %
 %
 % Jonathan Robinson, 2018-09-24
+% Hao Wang, 2018-10-05
 
 
 % handle input args


### PR DESCRIPTION
### Main improvements in this PR:
* fix: Replace `readtable` with `textscan` function in `addCuratedComplexRulesToModel.m` to fix the overload error when reading extremely long grRules


**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `devel` as a target branch
