### PR TITLE
merge fix/RemoveGlutamateSubsys branch into devel

### DIFF
--- a/ComplementaryScripts/modelCuration/mergeGlutamateSubsystem.m
+++ b/ComplementaryScripts/modelCuration/mergeGlutamateSubsystem.m
@@ -1,7 +1,8 @@
 %
-% FILE NAME:    removeGlutamateSubsystem.m
+% FILE NAME:    mergeGlutamateSubsystem.m
 % 
 % DATE CREATED: 2019-04-05
+%     MODIFIED: 2019-04-11
 % 
 % PROGRAMMER:   Jonathan Robinson
 %               Department of Biology and Biological Engineering


### PR DESCRIPTION
### Main improvements in this PR:
According to the map analysis in #87, the `Glutamate metabolism` subsystem only contained a single reaction, `4OHBUTm`. Instead of having a one-reaction subsystem, this model was merged into the `Alanine, aspartate and glutamate metabolism` subsystem.

This change is implemented with a script, `mergeGlutamateSubsystem.m`.

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `devel` as a target branch
