### PR TITLE
fix: getINITModel2

### DIFF
--- a/ComplementaryScripts/Functions/tINIT/getINITModel2.m
+++ b/ComplementaryScripts/Functions/tINIT/getINITModel2.m
@@ -405,7 +405,7 @@ I = ~ismember(excModel.mets,model.mets) & excModel.unconstrained == 0;
 excModel = removeReactions(excModel,J,true,true);
 
 % Merge with the output model
-model = mergeModels({model;excModel});
+model = mergeModels({model;excModel},'metNames');
 model.id = 'INITModel';
 model.description = ['Automatically generated model for ' tissue];
 if any(celltype)

--- a/ComplementaryScripts/Functions/tINIT/getINITModel2.m
+++ b/ComplementaryScripts/Functions/tINIT/getINITModel2.m
@@ -116,7 +116,7 @@ function [model, metProduction, essentialRxnsForTasks, addedRxnsForTasks, delete
 %               printReport, taskStructure, params, paramsFT);
 %
 %
-%   Jonathan Robinson, 2019-02-09
+%   Jonathan Robinson, 2019-10-14
 %
 
 if nargin < 5
@@ -309,7 +309,7 @@ if ~isempty(taskStructure)
     %Find metabolites present in taskStruct. We want to avoid removing
     %these metabolites from the final model (even though they may no longer
     %participate in any reacitons) so that the final model is still able to
-    %complete all of the tasks without an errors.
+    %complete all of the tasks without any errors.
     taskMets = union(vertcat(taskStructure.inputs),vertcat(taskStructure.outputs));
     modelMets = strcat(cModel.metNames,'[',cModel.comps(cModel.metComps),']');
     [inModel,metInd] = ismember(taskMets,modelMets);
@@ -338,7 +338,7 @@ end
 [~, deletedRxnsInINIT, metProduction] = runINIT(simplifyModel(cModel),rxnScores,metabolomicsData,essentialRxnsForTasks,0,true,false,params);
 initModel = removeReactions(cModel,deletedRxnsInINIT,false,true);
 
-% remove metabolites separately, to avoid removing those needed for tasks
+% remove metabolites separately to avoid removing those needed for tasks
 unusedMets = initModel.mets(all(initModel.S == 0,2));
 initModel = removeMets(initModel, setdiff(unusedMets,essentialMetsForTasks));
 

--- a/ComplementaryScripts/Functions/tINIT/getINITModel2.m
+++ b/ComplementaryScripts/Functions/tINIT/getINITModel2.m
@@ -326,7 +326,7 @@ else
 end
 
 % Score the connected model
-[rxnScores, geneScores] = scoreComplexModel(cModel,hpaData,arrayData,tissue,celltype);
+rxnScores = scoreComplexModel(cModel,hpaData,arrayData,tissue,celltype);
 
 %Run the INIT algorithm. The exchange reactions that are used in the final
 %model will be open, which doesn't fit with the last step. Therefore
@@ -394,8 +394,8 @@ model = outModel;
 % See the "removeLowScoreGenes" function more more details, and to adjust
 % any default parameters therein.
 if ( removeGenes )
-    [~, I]=ismember(model.genes,cModel.genes);
-    model = removeLowScoreGenes(model,geneScores(I));
+    [~, geneScores] = scoreComplexModel(model,hpaData,arrayData,tissue,celltype);
+    model = removeLowScoreGenes(model,geneScores);
 end
 
 


### PR DESCRIPTION
### Main improvements in this PR:
This PR fixes a small bug in `getINITModel2` where metabolites defined as inputs or outputs to metabolic tasks would be removed and then re-added to the model with a different ID. The function now prevents the removal of task-associated metabolites from the start, to avoid confusion with re-named metabolites in the final model.

**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `devel` as a target branch
