### PR TITLE
fix: remove inchi entries that conflict with metFormulas

### DIFF
--- a/ComplementaryScripts/modelCuration/removeConflictingInchiStrings.m
+++ b/ComplementaryScripts/modelCuration/removeConflictingInchiStrings.m
@@ -1,22 +1,24 @@
-function updated_model = updateModelInchiStrings(model)
+function corrected_model = removeConflictingInchiStrings(model)
 % Removes inchi strings that conflict with their corresponding metFormula
 %
 % Input:
 %
-%   model           model structure
+%   model   model structure
 %
 %
 % Output:
 %
-%   updated_model   model structure with updated "inchis" field
+%   corrected_model   model structure with "inchis" field updated such that
+%                     all entries conflicting with the corresponding entry
+%                     in the "metFormulas" field have been removed.
 %
 %
 % Usage:
 %
-%   updated_model = updateModelInchiStrings(model);
+%   corrected_model = removeConflictingInchiStrings(model);
 %
 %
-% Jonathan Robinson, 2019-10-28
+% Jonathan Robinson, 2019-12-04
 
 
 if ~isfield(model,'inchis')
@@ -49,6 +51,6 @@ else
     fprintf('No InChI conflicts were identified.\n');
 end
 
-updated_model = model;
+corrected_model = model;
 
 

--- a/ComplementaryScripts/modelCuration/updateModelInchiStrings.m
+++ b/ComplementaryScripts/modelCuration/updateModelInchiStrings.m
@@ -1,0 +1,51 @@
+function updated_model = updateModelInchiStrings(model)
+% Removes inchi strings that conflict with their corresponding metFormula
+%
+% Input:
+%
+%   model           model structure
+%
+%
+% Output:
+%
+%   updated_model   model structure with updated "inchis" field
+%
+%
+% Usage:
+%
+%   updated_model = updateModelInchiStrings(model);
+%
+%
+% Jonathan Robinson, 2019-10-28
+
+
+if ~isfield(model,'inchis')
+    error('Could not find field named "inchis" in the model (case-sensitive).');
+end
+    
+% identify non-empty inchis entries and extract formulas
+ind = find(~cellfun(@isempty, model.inchis));
+inchiSplit = cellfun(@(i) strsplit(i,'/'), model.inchis(ind), 'UniformOutput', false);
+inchiFormulas = cellfun(@(i) i{2}, inchiSplit, 'UniformOutput', false);
+inchiFormulas = regexprep(inchiFormulas,'[^a-zA-Z0-9]','');  % remove special characters
+
+% extract elemental composition of formulas
+metFormulas = model.metFormulas(ind);
+combinedFormulas = [inchiFormulas; metFormulas];
+[~,elMat] = parseFormulas(combinedFormulas);
+
+% compare formula composition and remove inchi entries that disagree
+inchiMat = elMat(1:numel(ind),:);
+formulaMat = elMat(numel(ind)+1:end,:);
+mismatch = any((inchiMat - formulaMat) ~= 0, 2);
+model.inchis(ind(mismatch)) = {''};
+
+if any(mismatch)
+    fprintf('Removed %u conflicting InChI strings.\n', sum(mismatch));
+else
+    fprintf('No InChI conflicts were identified.\n');
+end
+
+updated_model = model;
+
+

--- a/ComplementaryScripts/modelCuration/updateModelInchiStrings.m
+++ b/ComplementaryScripts/modelCuration/updateModelInchiStrings.m
@@ -23,8 +23,11 @@ if ~isfield(model,'inchis')
     error('Could not find field named "inchis" in the model (case-sensitive).');
 end
     
-% identify non-empty inchis entries and extract formulas
+% identify non-empty inchis entries
 ind = find(~cellfun(@isempty, model.inchis));
+
+% extract formulas from inchis strings, which are composed of segments
+% separated by delimiter (/) and formula is from the 2nd segment
 inchiSplit = cellfun(@(i) strsplit(i,'/'), model.inchis(ind), 'UniformOutput', false);
 inchiFormulas = cellfun(@(i) i{2}, inchiSplit, 'UniformOutput', false);
 inchiFormulas = regexprep(inchiFormulas,'[^a-zA-Z0-9]','');  % remove special characters


### PR DESCRIPTION
### Main improvements in this PR:
Many of the entries in the `inchis` field are out of sync with the `metFormulas` field (see issue #145).

This PR introduces a new function `removeConflictingInchiStrings` that compares all non-empty `inchis` entries with their corresponding entry in `metFormulas` and deletes the `inchis` entry if they disagree. This function (or some variant) could be re-run on the model anytime the `metFormulas` or `inchis` fields are modified to ensure that they remain synced.

The model can be updated by simply running the following command:
`ihuman = removeConflictingInchiStrings(ihuman);`

**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `devel` as a target branch
