### PR TITLE
feat: add model annotations prior to exporting SBML

### DIFF
--- a/ComplementaryScripts/Functions/exportHumanGEM.m
+++ b/ComplementaryScripts/Functions/exportHumanGEM.m
@@ -106,9 +106,9 @@ end
 
 % Write XML format
 if ismember('xml', formats)
-    model = simplifyModel(ihuman,false,false,true);  % remove inactivated rxns
-    model = annotateModel(model);  % add annotation data to structure
-    exportModel(model,fullfile(path,'ModelFiles','xml',strcat(prefix,'.xml')));
+    ihuman = simplifyModel(ihuman,false,false,true);  % remove inactivated rxns
+    ihuman = annotateModel(ihuman);  % add annotation data to structure
+    exportModel(ihuman,fullfile(path,'ModelFiles','xml',strcat(prefix,'.xml')));
 end
 
 %Save file with versions:

--- a/ComplementaryScripts/Functions/exportHumanGEM.m
+++ b/ComplementaryScripts/Functions/exportHumanGEM.m
@@ -106,7 +106,9 @@ end
 
 % Write XML format
 if ismember('xml', formats)
-    exportModel(ihuman,fullfile(path,'ModelFiles','xml',strcat(prefix,'.xml')));
+    model = simplifyModel(ihuman,false,false,true);  % remove inactivated rxns
+    model = annotateModel(model);  % add annotation data to structure
+    exportModel(model,fullfile(path,'ModelFiles','xml',strcat(prefix,'.xml')));
 end
 
 %Save file with versions:


### PR DESCRIPTION
The `exportHumanGEM` function is updated with the following two changes:
- Use `annotateModel` function to add annotations to model prior to exporting to SBML.
- Remove inactivated reactions (those with `lb == ub == 0`) prior to exporting to SBML, as some software/tools treat this as active reactions.


**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `devel` as a target branch
