### PR TITLE
fix: getINITModel2

### DIFF
--- a/ComplementaryScripts/Functions/tINIT/getINITModel2.m
+++ b/ComplementaryScripts/Functions/tINIT/getINITModel2.m
@@ -311,6 +311,7 @@ if ~isempty(taskStructure)
     %participate in any reacitons) so that the final model is still able to
     %complete all of the tasks without any errors.
     taskMets = union(vertcat(taskStructure.inputs),vertcat(taskStructure.outputs));
+    taskMets = union(taskMets, parseRxnEqu(vertcat(taskStructure.equations)));
     modelMets = strcat(cModel.metNames,'[',cModel.comps(cModel.metComps),']');
     [inModel,metInd] = ismember(taskMets,modelMets);
     essentialMetsForTasks = cModel.mets(metInd(inModel));


### PR DESCRIPTION
### Main improvements in this PR:
Fixes a rare bug in `getINITModel2` involving metabolic tasks.

A previous fix to `getINITModel2` (PR #139) was made to ensure that metabolites included as inputs or outputs in the metabolic task file were not removed during the tINIT model generation process. This PR extends that fix to also include metabolites participating in reaction equations defined in the metabolic task file, to ensure that those metabolites also remain in the model.

This fix was recently tested with a dataset used in tINIT model generation, which repeatedly errored due to metabolites defined in the task file that were not present in the resulting model. After applying the fix, the model was successfully generated without errors.

**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `devel` as a target branch
