### PR TITLE
fix: add glpk as dependency for swiglpk

### DIFF
--- a/.github/workflows/yaml-validation.yml
+++ b/.github/workflows/yaml-validation.yml
@@ -29,6 +29,9 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Install GLPK, dependecy for swiglpk
+      run: sudo apt-get install glpk-utils libglpk-dev
+
     - name: Test import with cobrapy and consistency with annotation files
       run: |
         pip install cobra


### PR DESCRIPTION
### Main improvements in this PR:
There seems to be a problem in recent runs of the Actions. `swiglpk` doesn't get installed because of a missing dependency `glpsol`. By adding that dependency, we can hopefully get the workflow to work again.

**I hereby confirm that I have:**

- [ ] Tested my code on my own computer for running the model
- [x] Selected `devel` as a target branch
