### PR TITLE
Fix: invalid InChI strings stored in YAML

### DIFF
--- a/code/io/exportHumanGEM.m
+++ b/code/io/exportHumanGEM.m
@@ -107,7 +107,6 @@ end
 % Write XML format
 if ismember('xml', formats)
     model = annotateModel(ihuman);  % add annotation data to structure
-    model = rmfield(model,'inchis');  % temporarily remove inchis until export function is updated
     model.id = regexprep(model.id,'-','');  % remove dash from model ID since it causes problems with SBML I/O
     exportModel(model,fullfile(path,'model',strcat(prefix,'.xml')));
 end


### PR DESCRIPTION
### Main improvements in this PR:
Fix issues found in the InChI strings stored in the YAML format of the model:
- **716** missing prefixes on InChI string (must start with `InChI=`)
- duplicated InChI on **2** metabolites having different names
- **338** missing InChI string for some of the compartmentalized metabolites
- **2** Inconsistencies between `inchi formula` and `metFormula`
Fixes #220 

**I hereby confirm that I have:**

- [x] Tested my code on my own computer for running the model
- [x] Selected `devel` as a target branch
