### PR TITLE
chore: master renamed main

### DIFF
--- a/.deprecated/code/modelCuration/GPRs/combineModelGPRs.m
+++ b/.deprecated/code/modelCuration/GPRs/combineModelGPRs.m
@@ -1,7 +1,7 @@
 function humanGEM_new = combineModelGPRs(humanGEM,iHsa,Recon3D)
 %combineModelGPRs  Combine the GPRs of HMR, iHsa, and Recon3D.
 % 
-%   This is the master function for combining and integrating genes and
+%   This is the main function for combining and integrating genes and
 %   grRules from HMR2, iHsa, and Recon3D into humanGEM. The function makes
 %   use of the "integrateGeneRules.m" and "translateGrRules.m" functions,
 %   among others.

--- a/.deprecated/code/modelCuration/GPRs/combineModelGPRsScript.m
+++ b/.deprecated/code/modelCuration/GPRs/combineModelGPRsScript.m
@@ -1,4 +1,4 @@
-% Master script for combining and integrating genes and grRules from HMR2
+% Main script for combining and integrating genes and grRules from HMR2
 % iHsa, and Recon3D into the merged model. The script makes use of the
 % "integrateGeneRules.m" and "translateGrRules.m" functions, among
 % others.

--- a/.deprecated/code/modelCuration/MetAssociation/HMR_master_met_curation.m
+++ b/.deprecated/code/modelCuration/MetAssociation/HMR_master_met_curation.m
@@ -1,4 +1,4 @@
-% Master script for curating and mapping HMR and Recon metabolites
+% Main script for curating and mapping HMR and Recon metabolites
 %
 
 

--- a/.deprecated/code/modelCuration/modelIntegration/integrateRecon3DToHMR.m
+++ b/.deprecated/code/modelCuration/modelIntegration/integrateRecon3DToHMR.m
@@ -1,7 +1,7 @@
 %
 % FILE NAME:    integrateRecon3DToHMR.m
 % 
-% PURPOSE: The master scrit for integrate Recon3D into HMR2 based on
+% PURPOSE: The main script for integrate Recon3D into HMR2 based on
 %          reaction/metabolite association to MetaNetX/BiGG databases
 %
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,7 +19,7 @@ If you are unsure about the issue, consider asking first in our [Gitter chat roo
 When creating the issue, please make sure:
 
 * You tested your code (if any) with all requirements for running the model.
-* You did your analysis in the `master` branch of the repository.
+* You did your analysis in the `main` branch of the repository.
 * You provide any necessary files/links needed for understanding the issue.
 * You checked that a similar issue does not exist already
 
@@ -76,7 +76,7 @@ Thank you very much for contributing to Human-GEM!
 
 * `devel`: Is the branch to which all pull requests should be made.
 
-* `master`: Is only modified by the administrator and is the branch with the tested & reviewed model that is released or ready for the next release.
+* `main`: Is only modified by the administrator and is the branch with the tested & reviewed model that is released or ready for the next release.
 
 * `{chore, doc, feat, fix, refactor, style}/descriptive-name`: Any other branch created in the model. If you work on a fix, start the branch name with `fix/`, if you work on a feature, start the branch name with `feat/`. Examples: `fix/format_reactions` or `feat/new_algorithms`. [See below](#semantic-commits) for more details on the possible actions you can use.
 	
@@ -105,9 +105,9 @@ Some examples:
 |Split a rxn in 2|`refactor: split isomerase in 2 steps`|
 |Update documentation of function|`doc: addDBnewRxn.m update documentation`|
 
-More examples [here](https://github.com/SysBioChalmers/Human-GEM/commits/master). A more detailed explanation or comments is encouraged to be left in the commit description.
+More examples [here](https://github.com/SysBioChalmers/Human-GEM/commits/main). A more detailed explanation or comments is encouraged to be left in the commit description.
 
 
 ## Acknowledgments
 
-These contribution guidelines were adapted from the guidelines of [SysBioChalmers/yeast-GEM](https://github.com/SysBioChalmers/yeast-GEM/blob/master/.github/CONTRIBUTING.md).
+These contribution guidelines were adapted from the guidelines of [SysBioChalmers/yeast-GEM](https://github.com/SysBioChalmers/yeast-GEM/blob/main/.github/CONTRIBUTING.md).

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -7,7 +7,7 @@
 
 
 #### Current feature/value/output:
-*How the reaction/metabolite/gene/simulation actually looks in the `master` branch. PLEASE DELETE THIS LINE.*
+*How the reaction/metabolite/gene/simulation actually looks in the `main` branch. PLEASE DELETE THIS LINE.*
 
 
 #### Reproducing these results:
@@ -18,7 +18,7 @@
 
 **I hereby confirm that I have:**
 - [ ] Tested my code on my own computer for running the model
-- [ ] Done this analysis in the `master` branch of the repository
+- [ ] Done this analysis in the `main` branch of the repository
 - [ ] Checked that a similar issue does not exist already
 
 *Note: replace [ ] with [X] to check the box. PLEASE DELETE THIS LINE*

--- a/.github/workflows/yaml-validation.yml
+++ b/.github/workflows/yaml-validation.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
 
 jobs:
   yaml-validation:

--- a/.standard-GEM.md
+++ b/.standard-GEM.md
@@ -22,7 +22,7 @@ With further updates to `standard-GEM`, one should paste over the new version of
 Repository creation
 -------------------
 - [x] 🟨 Navigate to [standard-GEM](https://github.com/MetabolicAtlas/standard-GEM/) and click on the button `Use this template`  
-The `standard-GEM` template can be used to initiate a repository. This will copy the contents of the _master_ branch into the new repository, which can be either private or public.
+The `standard-GEM` template can be used to initiate a repository. This will copy the contents of the _main_ branch into the new repository, which can be either private or public.
 
 - [x] 🟥 Pick a repository name  
 The name must be either a common name, KEGG organism, or taxonomy-derived short name, followed by the extension `-GEM` or `-GSMM`. The `-GEM` extension is preferred to ease pronunciation. The name can be prefixed by an abbreviation, eg `ec` (enzyme constrained), `sec` (with secretory pathways), `mito` (with mitochondrion pathways), `pro` (with protein structures).  
@@ -43,7 +43,7 @@ The URL can be the _doi_.
 Repository workflow
 -------------------
 - [x] 🟥 Git branches  
-The GEM repository must have at least two branches: _master_ and _develop_.
+The GEM repository must have at least two branches: _main_ and _develop_.
 
 - [ ] 🟥 Releases  
 Releases must use the tag format `X.X.X` where X are numbers, according to [semantic versioning principles](https://semver.org/). The last field (“patch”) can also be used to indicate changes to the repository that do not actually change the GEM itself. The use of a `v` before the version number (`v1.0`) is [discouraged](https://semver.org/#is-v123-a-semantic-version).
@@ -64,7 +64,7 @@ The repository must contain a `/.gitignore` file. This generic [.gitignore](http
 The repository must contain a `/.github` folder, in which the contributing guidelines, code of conduct, issue templates and pull request templates must be placed. Defaults are provided and they do not require any modification.
 
 - [x] 🟥 `/.github/CONTRIBUTING.md`  
-This file is provided by the template, but it is empty. It must be filled in with the adequate contributing guideline instructions; a good example is https://github.com/SysBioChalmers/yeast-GEM/blob/master/.github/CONTRIBUTING.md.
+This file is provided by the template, but it is empty. It must be filled in with the adequate contributing guideline instructions; a good example is https://github.com/SysBioChalmers/yeast-GEM/blob/main/.github/CONTRIBUTING.md.
 
 - [x] 🟥 `/code/README.md`  
 The repository must contain a `/code` folder. This folder must contain all the code used in generating the model. It must also include a `README.md` file that describes how the folder is organized.
@@ -74,12 +74,12 @@ The repository must contain a `/data` folder. This folder contains the data used
 
 - [x] 🟥 `/model`  
 The repository must contain `/model` folder.  
-This folder must contain the model files, in multiple formats, according to the table below. As a general guideline, binary formats (`.mat`, `.xlsx`) must not exist on any other branches than _master_. The main reason for this is that binary files cannot be diff'ed, which means changes cannot be compared to previous versions, thus increasing the chance of errors. Moreover, with time, the size of the repository can create difficulties, and we cannot yet recommend storing these files with Git LFS, as it introducs complexity.  
+This folder must contain the model files, in multiple formats, according to the table below. As a general guideline, binary formats (`.mat`, `.xlsx`) must not exist on any other branches than _main_. The main reason for this is that binary files cannot be diff'ed, which means changes cannot be compared to previous versions, thus increasing the chance of errors. Moreover, with time, the size of the repository can create difficulties, and we cannot yet recommend storing these files with Git LFS, as it introducs complexity.  
 For more information on the `sbtab` file format, see [sbtab.net](https://sbtab.net).  
 All model files must be named the same as the repository, and with the appropriate extension.  
 Example: `yeast-GEM.mat`
 
-| Model file format | _master_ branch | _develop_ and other branches |
+| Model file format | _main_ branch | _develop_ and other branches |
 | ----------------- | --------------- | ---------------------------- |
 | JSON `.json`      | can             ||
 | Matlab `.mat`     | should          | must not                     |
@@ -106,4 +106,4 @@ The repository must contain this file, which is required for the version badge i
 The repository can be set up for continuous integration testing using memote with eg. Travis CI (`.travis.yml`), Jenkins (`Jenkinsfile`), GitHub Actions (under `.github/workflows`).
 
 - [ ] 🟨 _MEMOTE_ report  
-The repository could contain a [MEMOTE](https://www.nature.com/articles/s41587-020-0446-y) report on the _master_ branch, in `.html` format.
+The repository could contain a [MEMOTE](https://www.nature.com/articles/s41587-020-0446-y) report on the _main_ branch, in `.html` format.

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Detailed instructions on the installation and use of the Human-GEM model and rep
 
 
 ### Installation Instructions
-* Clone the [master branch](https://github.com/SysBioChalmers/Human-GEM/tree/master) of this repository, or [download the latest release](https://github.com/SysBioChalmers/Human-GEM/releases/latest).
+* Clone the [main branch](https://github.com/SysBioChalmers/Human-GEM/tree/main) of this repository, or [download the latest release](https://github.com/SysBioChalmers/Human-GEM/releases/latest).
 * Add the directory to your MATLAB path (instructions [here](https://se.mathworks.com/help/matlab/ref/addpath.html?requestedDomain=www.mathworks.com)).
 
 
 
 ## Model Files
 
-The model is available as `.xml`, `.xlsx`, `.txt`, `.yml`, and `.mat` in the `model/` directory. Note that only the `.yml` version is available on branches other than `master` (e.g., `develop`), to facilitate tracking of model changes.
+The model is available as `.xml`, `.xlsx`, `.txt`, `.yml`, and `.mat` in the `model/` directory. Note that only the `.yml` version is available on branches other than `main` (e.g., `develop`), to facilitate tracking of model changes.
 
 
 
@@ -69,7 +69,7 @@ The model is available as `.xml`, `.xlsx`, `.txt`, `.yml`, and `.mat` in the `mo
 
 #### Loading/saving the model
 
-`Human-GEM.mat` (Recommended if on `master` branch)
+`Human-GEM.mat` (Recommended if on `main` branch)
 * Load and save using the built-in MATLAB `load()` and `save()` functions.
 
 `Human-GEM.yml` (Recommended if on `develop` or other branches)
@@ -159,4 +159,4 @@ A collection of manually curated 2D metabolic maps associated with Human-GEM are
 
 ## Contributing
 
-Contributions are always welcome! Please read the [contribution guidelines](https://github.com/SysBioChalmers/Human-GEM/blob/master/.github/CONTRIBUTING.md) to get started.
+Contributions are always welcome! Please read the [contribution guidelines](https://github.com/SysBioChalmers/Human-GEM/blob/main/.github/CONTRIBUTING.md) to get started.

--- a/code/io/increaseHumanGEMVersion.m
+++ b/code/io/increaseHumanGEMVersion.m
@@ -9,10 +9,10 @@ function increaseHumanGEMVersion(bumpType)
 %
 
 
-%Check if in master:
+%Check if in main:
 currentBranch = git('rev-parse --abbrev-ref HEAD');
-if ~strcmp(currentBranch,'master')
-    error('ERROR: not in master')
+if ~strcmp(currentBranch,'main')
+    error('ERROR: not in main')
 end
 
 %Get model path


### PR DESCRIPTION
### Main improvements in this PR:
This PR follows the rename of the `master` branch to `main` as discussed in https://github.com/SysBioChalmers/Human-GEM/discussions/226, updating all the references. Moreover, it also replaces some other occurrences of the word `master`.

**I hereby confirm that I have:**

- [ ] Tested my code on my own computer for running the model
- [x] Passed `testYamlConversion` check
- [x] Selected `develop` as a target branch
