### PR TITLE
feat: enable GH actions to report reusing of deprecated reaction and metabolite identifiers

### DIFF
--- a/code/test/sanityCheck.py
+++ b/code/test/sanityCheck.py
@@ -49,7 +49,7 @@ def checkMetAnnotation(mets):
     """
     metList = get_column_from_tsv("model/metabolites.tsv", "mets")
     metDeprecated = get_column_from_tsv("data/deprecatedIdentifiers/deprecatedMetabolites.tsv", "mets")
-    assert not bool(set(metList) & set(metDeprecated)), "Deprecated metabolite reused!"
+    assert set(metList).isdisjoint(set(metDeprecated)), "Deprecated metabolite reused!"
     assert metList == mets, "Metabolite annotation mismatch!"
 
 

--- a/code/test/sanityCheck.py
+++ b/code/test/sanityCheck.py
@@ -37,6 +37,8 @@ def checkRxnAnnotation(rxns):
     """
     rxnList = get_column_from_tsv("model/reactions.tsv", "rxns")
     spontaneous = get_column_from_tsv("model/reactions.tsv", "spontaneous", False)
+    rxnDeprecated = get_column_from_tsv("data/deprecatedIdentifiers/deprecatedReactions.tsv", "rxns")
+    assert not bool(set(rxnList) & set(rxnDeprecated)), "Deprecated reaction reused!"
     assert rxnList == rxns, "Reaction annotation mismatch!"
     assert pd.api.types.is_numeric_dtype(spontaneous), "Spontaneous column should be in numeric!"
 
@@ -46,6 +48,8 @@ def checkMetAnnotation(mets):
     check consistency of met lists between model and annotation file
     """
     metList = get_column_from_tsv("model/metabolites.tsv", "mets")
+    metDeprecated = get_column_from_tsv("data/deprecatedIdentifiers/deprecatedMetabolites.tsv", "mets")
+    assert not bool(set(metList) & set(metDeprecated)), "Deprecated metabolite reused!"
     assert metList == mets, "Metabolite annotation mismatch!"
 
 
@@ -62,5 +66,5 @@ if __name__ == "__main__":
     checkRxnAnnotation(rxns)
     checkMetAnnotation(mets)
     checkGeneAnnotation(genes)
-    print("Everything passed")
+    print("Everything is passed.")
 

--- a/code/test/sanityCheck.py
+++ b/code/test/sanityCheck.py
@@ -6,6 +6,17 @@ import pandas as pd
 import cobra
 
 
+def get_column_from_tsv(tsv_file, column_id, to_list=True):
+    """
+    read a column from a tsv file and convert the content into a list by default
+    """
+    tsv_content = pd.read_table(tsv_file)
+    if to_list:
+        return tsv_content[column_id].to_list()
+    else:
+        return tsv_content[column_id]
+
+
 def load_yml(yml_file):
     """
     import yml model file, and output rxn and met lists
@@ -24,19 +35,17 @@ def checkRxnAnnotation(rxns):
     """
     check consistency of rxn lists between model and annotation file
     """
-    rxnAssoc = pd.read_table("model/reactions.tsv")
-    rxnList = rxnAssoc['rxns'].to_list()
+    rxnList = get_column_from_tsv("model/reactions.tsv", "rxns")
+    spontaneous = get_column_from_tsv("model/reactions.tsv", "spontaneous", False)
     assert rxnList == rxns, "Reaction annotation mismatch!"
-    assert pd.api.types.is_numeric_dtype(
-        rxnAssoc['spontaneous']), "Spontaneous column should be in numeric!"
+    assert pd.api.types.is_numeric_dtype(spontaneous), "Spontaneous column should be in numeric!"
 
 
 def checkMetAnnotation(mets):
     """
     check consistency of met lists between model and annotation file
     """
-    metAssoc = pd.read_table("model/metabolites.tsv")
-    metList = metAssoc['mets'].to_list()
+    metList = get_column_from_tsv("model/metabolites.tsv", "mets")
     assert metList == mets, "Metabolite annotation mismatch!"
 
 
@@ -44,8 +53,7 @@ def checkGeneAnnotation(genes):
     """
     check consistency of gene lists between model and annotation file
     """
-    geneAssoc = pd.read_table("model/genes.tsv")
-    geneList = geneAssoc['genes'].to_list()
+    geneList = get_column_from_tsv("model/genes.tsv", "genes")
     assert geneList == genes, "Gene annotation mismatch!"
 
 

--- a/code/test/sanityCheck.py
+++ b/code/test/sanityCheck.py
@@ -11,10 +11,10 @@ def get_column_from_tsv(tsv_file, column_id, to_list=True):
     read a column from a tsv file and convert the content into a list by default
     """
     tsv_content = pd.read_table(tsv_file)
+    desired_column = tsv_content[column_id]
     if to_list:
-        return tsv_content[column_id].to_list()
-    else:
-        return tsv_content[column_id]
+        return desired_column.to_list()
+    return desired_column
 
 
 def load_yml(yml_file):
@@ -67,4 +67,3 @@ if __name__ == "__main__":
     checkMetAnnotation(mets)
     checkGeneAnnotation(genes)
     print("Everything is passed.")
-

--- a/code/test/sanityCheck.py
+++ b/code/test/sanityCheck.py
@@ -38,7 +38,7 @@ def checkRxnAnnotation(rxns):
     rxnList = get_column_from_tsv("model/reactions.tsv", "rxns")
     spontaneous = get_column_from_tsv("model/reactions.tsv", "spontaneous", False)
     rxnDeprecated = get_column_from_tsv("data/deprecatedIdentifiers/deprecatedReactions.tsv", "rxns")
-    assert not bool(set(rxnList) & set(rxnDeprecated)), "Deprecated reaction reused!"
+    assert set(rxnList).isdisjoint(set(rxnDeprecated)), "Deprecated reaction reused!"
     assert rxnList == rxns, "Reaction annotation mismatch!"
     assert pd.api.types.is_numeric_dtype(spontaneous), "Spontaneous column should be in numeric!"
 

--- a/code/test/sanityCheck.py
+++ b/code/test/sanityCheck.py
@@ -66,4 +66,4 @@ if __name__ == "__main__":
     checkRxnAnnotation(rxns)
     checkMetAnnotation(mets)
     checkGeneAnnotation(genes)
-    print("Everything is passed.")
+    print("All checks have passed.")


### PR DESCRIPTION
### Main improvements in this PR:
* Adjust `sanityCheck` script to detect the cases of reusing deprecated reaction and metabolite identifiers, as discussed in #265.

**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch

