### PR TITLE
doc: simplify `contributing guidelines` and improve the visibility to contributors

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If you want to contribute to the model with some additions or improvements, plea
 
 Here's how to set up Human-GEM to contribute small features or changes. This should work for most curation work.
 
-1. Fork the [Human-GEM](https://github.com/SysBioChalmers/Human-GEM) repository to your local, by clicking on the upper right corner. And then switch to `develop` branch in the forked repo.
+1. Fork the [Human-GEM](https://github.com/SysBioChalmers/Human-GEM) repository to your local, by clicking on the upper right corner. Then, switch to the `develop` branch before starting to work in the forked repository.
 
 2. Modify model file `Human-GEM.yml` and/or annotation files `reactions.tsv`, `metabolites.tsv`, and `genes.tsv`, and commit changes as suggested below in "Semantic commits". 
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,11 +31,11 @@ Feel free to also comment on any of the [open issues](https://github.com/SysBioC
 If you want to contribute to the model with some additions or improvements, please always start by raising an issue for asking/describing what you want to achieve. This way, we reduce the risk of duplicated efforts and you may also get suggestions on how to best proceed, e.g. there may be half-finished work in some branch that you could work with. Also, feel free to browse our [open issues](https://github.com/SysBioChalmers/Human-GEM/issues) and our [ongoing projects](https://github.com/SysBioChalmers/Human-GEM/projects): Anything tagged with "help wanted" is open to whoever wants to implement it.
 
 
-- Here's how to set up Human-GEM to contribute small features or changes. This should work for most of the curations.
+Here's how to set up Human-GEM to contribute small features or changes. This should work for most curation work.
 
 1. Fork the [Human-GEM](https://github.com/SysBioChalmers/Human-GEM) repository to your local, by clicking on the upper right corner. And then switch to `develop` branch in the forked repo.
 
-2. Modify model file `Human-GEM.yml` and/or annotation files `reactions.tsv`, `metabolites.tsv`, and `genes.tsv`.
+2. Modify model file `Human-GEM.yml` and/or annotation files `reactions.tsv`, `metabolites.tsv`, and `genes.tsv`, and commit changes as suggested below in "Semantic commits". 
 
 3. Submit a pull request from the `develop` branch of the forked repo on GitHub website to the `develop` branch of the original repo. We recommend ticking the box "Allow edits from maintainers" if you wish for us to be able to contribute directly to your branch (speeding-up the reviewing process).
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,14 +1,14 @@
-## Contributor guidelines
+## Contributing guidelines
 
-Contributions to Human-GEM are very welcome and greatly appreciated! Credit will always be given to anyone who contribute.
+Contributions to **Human-GEM** are very welcome and greatly appreciated! Credit will always be given to anyone who contribute.
 
-You can contribute in 2 main ways: by creating issues, and by sending pull requests (PRs) with additions, deletions, corrections, etc. to the model. Please follow the following guidelines:
+You can contribute in **2** major ways: by creating issues, and by sending pull requests (PRs) with additions, deletions, corrections, etc. to the `yml` model and/or `tsv` annotation files. Please follow the following guidelines:
 
-### Reporting issues in the model
+### Reporting issues
 
-Report an issue at https://github.com/SysBioChalmers/Human-GEM/issues if you note any of the following:
+Report an issue at [here](https://github.com/SysBioChalmers/Human-GEM/issues), if you notice any of the following:
 
-* Incorrect annotation for any model component.
+* Incorrect annotation for any model components.
 * Missing feature or field you would like the model to have.
 * Bug/weird simulation results.
 * Lacking documentation.
@@ -18,63 +18,35 @@ If you are unsure about the issue, consider asking first in our [Gitter chat roo
 
 When creating the issue, please make sure:
 
+* You checked that a similar issue does not exist already
 * You tested your code (if any) with all requirements for running the model.
 * You did your analysis in the `main` branch of the repository.
 * You provide any necessary files/links needed for understanding the issue.
-* You checked that a similar issue does not exist already
 
 Feel free to also comment on any of the [open issues](https://github.com/SysBioChalmers/Human-GEM/issues).
 
 
-### Contributing to the model
+### Contributing to the model/annotation
 
-If you want to contribute to the model with some additions or improvements, please consider starting by raising an issue and assign it to yourself to describe what you want to achieve. This way, we reduce the risk of duplicated efforts and you may also get suggestions on how to best proceed, e.g. there may be half-finished work in some branch that you could start with. Also, feel free to browse our [open issues](https://github.com/SysBioChalmers/Human-GEM/issues) and our [ongoing projects](https://github.com/SysBioChalmers/Human-GEM/projects): Anything tagged with "help wanted" is open to whoever wants to implement it.
+If you want to contribute to the model with some additions or improvements, please always start by raising an issue for asking/describing what you want to achieve. This way, we reduce the risk of duplicated efforts and you may also get suggestions on how to best proceed, e.g. there may be half-finished work in some branch that you could work with. Also, feel free to browse our [open issues](https://github.com/SysBioChalmers/Human-GEM/issues) and our [ongoing projects](https://github.com/SysBioChalmers/Human-GEM/projects): Anything tagged with "help wanted" is open to whoever wants to implement it.
 
-Here's how to set up Human-GEM for local development to contribute smaller features or changes that you can implement yourself:
 
-1. Make sure that you have all [requirements](https://github.com/SysBioChalmers/Human-GEM#required-software) for contributing to Human-GEM. Note that COBRA and RAVEN should be cloned to your computer and not just downloaded.
+- Here's how to set up Human-GEM to contribute small features or changes. This should work for most of the curations.
 
-2. Fork the Human-GEM repository on GitHub (go to https://github.com/SysBioChalmers/Human-GEM & click on the upper right corner).
+1. Fork the [Human-GEM](https://github.com/SysBioChalmers/Human-GEM) repository to your local, by clicking on the upper right corner. And then switch to `develop` branch in the forked repo.
 
-3. Clone your fork locally:
-    ```
-    git clone https://github.com/<your Github name>/Human-GEM.git
-    ```
-	
-4. Check out the branch that you want to contribute to. Most likely that will be `devel`:
-    ```
-    git checkout devel
-    ```
-	
-5. Create a branch for local development based on the previously checked out branch ([see below](#branching-model) for details on the branching model and how to name your branch):
-    ```
-    git checkout -b name-of-your-branch
-    ```
-	
-6. Now you can make your changes locally!
-    * If your changes are minor (e.g. a single chemical formula you wish to correct), you can do it directly from the command line.
-    * If your changes are not so small and require several steps, create a script that loads the model, reads data (if applicable), changes the model accordingly, and saves the model back.
-    * Each script should start with a commented section describing the script, explaining the parameters, and indicating your name and the date it was written. Existing functions can clarify what style should be used.
-    * Store scripts in the appropriate folder in `/code` and data (as `.tsv` files) in the appropriate folder in `/data`. If you think no folder is adequate for your script/data, feel free to create your own folder. Note that binary data such as `.mat` structures or `.xls` tables cannot be stored in the repo (as they cannot be version-controlled, and they increment too much the size of the repo).
-    * When you are done making changes, review locally your changes with `git diff` or any git client, to make sure you are modifying the model as you intended.
+2. Modify model file `Human-GEM.yml` and/or annotation files `reactions.tsv`, `metabolites.tsv`, and `genes.tsv`.
 
-7. Commit your changes and push your branch to GitHub.
-    ```
-    git add .
-    git commit -m "Title of your commit"
-    git push origin name-of-your-branch
-    ```
-    [See below](#semantic-commits) for recommendations on how to name your commits. In case of larger updates, you can of course make several commits on a single contribution. However, if you need to make many commits, consider if your contribution could be instead split into separate branches (making it easier for reviewing later).
+3. Submit a pull request from the `develop` branch of the forked repo on GitHub website to the `develop` branch of the original repo. We recommend ticking the box "Allow edits from maintainers" if you wish for us to be able to contribute directly to your branch (speeding-up the reviewing process).
 
-8. Submit a pull request through the GitHub website (https://help.github.com/articles/creating-a-pull-request-from-a-fork/) to the `devel` branch of the original SysBioChalmers repo (not to your fork). We recommend ticking the box "Allow edits from maintainers" if you wish for us to be able to contribute directly to your branch (speeding-up the reviewing process).
 
-Finally, and for larger features that you want to work on collaboratively, you may consider to first request to join our development team to get write access to the repository so that you can create a branch directly in the main repository (or simply ask the administrator to create a branch for you). Once you have a new branch, you can push your changes directly to the main repository and when finished, submit a pull request from that branch to `devel`. [See below](#development-team-guidelines) for more details.
+Finally, and for larger features that you want to work on collaboratively, you may consider to first request to join our development team to get write access to the repository so that you can create a branch directly in the main repository (or simply ask the administrator to create a branch for you). Once you have a new branch, you can push your changes directly to the main repository and when finished, submit a pull request from that branch to `develop`. [See below](#development-team-guidelines) for more details.
 
 Thank you very much for contributing to Human-GEM!
 
 #### Branching model
 
-* `devel`: Is the branch to which all pull requests should be made.
+* `develop`: Is the branch to which all pull requests should be made.
 
 * `main`: Is only modified by the administrator and is the branch with the tested & reviewed model that is released or ready for the next release.
 
@@ -110,4 +82,5 @@ More examples [here](https://github.com/SysBioChalmers/Human-GEM/commits/main). 
 
 ## Acknowledgments
 
-These contribution guidelines were adapted from the guidelines of [SysBioChalmers/yeast-GEM](https://github.com/SysBioChalmers/yeast-GEM/blob/main/.github/CONTRIBUTING.md).
+These contribution guidelines were adapted from the guidelines of [yeast-GEM](https://github.com/SysBioChalmers/yeast-GEM/blob/main/.github/CONTRIBUTING.md).
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Here's how to set up Human-GEM to contribute small features or changes. This sho
 
 2. Modify model file `Human-GEM.yml` and/or annotation files `reactions.tsv`, `metabolites.tsv`, and `genes.tsv`, and commit changes as suggested below in "Semantic commits". 
 
-3. Submit a pull request from the `develop` branch of the forked repo on GitHub website to the `develop` branch of the original repo. We recommend ticking the box "Allow edits from maintainers" if you wish for us to be able to contribute directly to your branch (speeding-up the reviewing process).
+3. Submit a pull request from the `develop` branch of the forked repository to the `develop` branch of the original `SysBioChalmers/Human-GEM` repository. We recommend ticking the box "Allow edits from maintainers" if you wish for us to be able to contribute directly to your branch (speeding-up the reviewing process).
 
 
 Finally, and for larger features that you want to work on collaboratively, you may consider to first request to join our development team to get write access to the repository so that you can create a branch directly in the main repository (or simply ask the administrator to create a branch for you). Once you have a new branch, you can push your changes directly to the main repository and when finished, submit a pull request from that branch to `develop`. [See below](#development-team-guidelines) for more details.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Contributing guidelines
 
-Contributions to **Human-GEM** are very welcome and greatly appreciated! Credit will always be given to anyone who contribute.
+Contributions to **Human-GEM** are very welcome and greatly appreciated! Credit is given to everyone who contributes. This is done by either manually modifying the `.all-contributorsrc` or automatically with the `all-contributors` bot, and updating the `Contributors` sections of the `README` accordingly.
 
 You can contribute in **2** major ways: by creating issues, and by sending pull requests (PRs) with additions, deletions, corrections, etc. to the `yml` model and/or `tsv` annotation files. Please follow the following guidelines:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you use Human1 in your research, please cite:
  
 Starting from Human-GEM v1.5.0, all the releases are also archived in [Zenodo](https://doi.org/10.5281/zenodo.4099692) from which specific version can be cited if used.
 
-If you use Mouse1, Rat1, Zebrafish1, Fruitfly1 or Worm1 in your research, please cite:   
+If you use Mouse1, Rat1, Zebrafish1, Fruitfly1, or Worm1 in your research, please cite:   
 
   > H. Wang, J. L. Robinson, P. Kocabaş, J. Gustafsson, M. Anton, P.-E. Cholley, et al. Genome-scale metabolic network reconstruction of model animals as a platform for translational research. _PNAS_ 118, e2102344118 (2021). [doi.org/10.1073/pnas.2102344118](https://doi.org/10.1073/pnas.2102344118)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ If you use Mouse1, Rat1, Zebrafish1, Fruitfly1 or Worm1 in your research, please
 
 This repository is administered by Jonathan Robinson ([@JonathanRob](https://github.com/jonathanrob)) and Hao Wang ([@Hao-Chalmers](https://github.com/hao-chalmers)), Division of Systems and Synthetic Biology, Department of Biology and Biological Engineering, Chalmers University of Technology.
 
+## Contributing
+
+Contributions are always welcome! Please read the [Contributing guidelines](https://github.com/SysBioChalmers/Human-GEM/blob/main/.github/CONTRIBUTING.md) before start.
+
 
 ## User Guide
 
@@ -163,10 +167,6 @@ To import/export this annotation data to/from MATLAB, use the `importTsvFile` an
 
 A collection of manually curated 2D metabolic maps associated with Human-GEM are stored in the [Human-maps repository](https://github.com/SysBioChalmers/Human-maps). These maps can be downloaded from the repository or explored interactively using [Metabolic Atlas](https://metabolicatlas.org/explore/map-viewer/human1).
 
-
-## Contributing
-
-Contributions are always welcome! Please read the [contribution guidelines](https://github.com/SysBioChalmers/Human-GEM/blob/main/.github/CONTRIBUTING.md) to get started.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -97,62 +97,7 @@ The model is available as `.xml`, `.xlsx`, `.txt`, `.yml`, and `.mat` in the `mo
 
 ## Reaction, Metabolite, and Gene Annotations
 
-Additional annotation information and external identifiers for Human-GEM reactions, metabolites, and genes are provided as `tsv` files in the `model/` directory. The structure of the `tsv` files are tabulated below.
-
-* `reactions.tsv` content:
-
-fieldname      |  annotation             |
----------------|------------------------ |
-rxns           |identical to `model.rxns`|
-rxnKEGGID      |KEGG reaction ID        |
-rxnBiGGID      |BiGG reaction ID        |
-rxnEHMNID      |EHMN reaction ID        |
-rxnHepatoNET1ID|HepatoNET1 reaction ID  |
-rxnREACTOMEID  |REACTOME ID             |
-rxnRecon3DID   |Recon3D reaction ID     |
-rxnMetaNetXID  |MetaNetX reaction ID    |
-rxnHMR2ID      |HMR2 reaction ID        |
-rxnRatconID    |Ratcon reaction ID      |
-rxnTCDBID      |TCDB ID                 |
-spontaneous    |Spontaneous status      |
-rxnMAID        |MA reaction ID          |
-rxnRheaID      |Rhea ID                 |
-rxnRheaMasterID|Master Rhea ID          |
-
-
-* `metabolites.tsv` content:
-
-fieldname      |  annotation             |
----------------|-------------------------|
-mets           |identical to `model.mets`|
-metsNoComp     |`model.mets` without compartment suffix|
-metBiGGID      |BiGG metabolite ID       |
-metKEGGID      |KEGG metabolite ID       |
-metHMDBID      |HMDB ID                  |
-metChEBIID     |ChEBI ID                 |
-metPubChemID   |PubChem ID               |
-metLipidMapsID |LipidMaps ID             |
-metEHMNID      |EHMN metabolite ID       |
-metHepatoNET1ID|HepatoNET1 metabolite ID |
-metRecon3DID   |Recon3D metabolite ID    |
-metMetaNetXID  |MetaNetX metabolite ID   |
-metHMR2ID      |HMR2 metabolite ID       |
-metMAID        |MA metabolite ID         |
-
-
-* `genes.tsv` content:
-
-fieldname     |  annotation          |
---------------|----------------------|
-genes         |Ensembl gene ID       |
-geneENSTID    |Ensembl transcript ID |
-geneENSPID    |Ensembl protein ID |
-geneUniProtID |UniProt ID            |
-geneSymbols   |Gene Symbol           |
-geneEntrezID  |NCBI Entrez ID        |
-geneNames     |Gene Name             |
-geneAliases   |Alias Names           |
-
+Additional annotation information and external identifiers for Human-GEM reactions, metabolites, and genes are provided as `tsv` files in the `model/` directory (`reactions.tsv`, `metabolites.tsv`, and `genes.tsv`, respectively).  
 
 To import/export this annotation data to/from MATLAB, use the `importTsvFile` and `exportTsvFile` functions, respectively.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### Brief Model Description
 
-This repository contains the latest version of Human-GEM, a human genome-scale metabolic model.
+This repository contains the latest version of Human-GEM, a human genome-scale metabolic model. We encourage [contributions](#contributing).
 
 ### Cite us:
 

--- a/model/README.md
+++ b/model/README.md
@@ -1,0 +1,70 @@
+# Human-GEM model and annotation files
+
+This directory contains the Human-GEM model and annotation files.
+
+
+## Model
+
+The model is available as `.xml`, `.xlsx`, `.txt`, `.yml`, and `.mat` in the `model/` directory. Note that only the `.yml` version is available on branches other than `main` (e.g., `develop`), to facilitate tracking of model changes.
+
+
+## Reaction, Metabolite, and Gene Annotations
+
+Additional annotation information and external identifiers for Human-GEM reactions, metabolites, and genes are provided as `tsv` files in the `model/` directory. The structure of the `tsv` files are tabulated below.
+
+* `reactions.tsv` content:
+
+fieldname      |  annotation             |
+---------------|------------------------ |
+rxns           |identical to `model.rxns`|
+rxnKEGGID      |KEGG reaction ID        |
+rxnBiGGID      |BiGG reaction ID        |
+rxnEHMNID      |EHMN reaction ID        |
+rxnHepatoNET1ID|HepatoNET1 reaction ID  |
+rxnREACTOMEID  |REACTOME ID             |
+rxnRecon3DID   |Recon3D reaction ID     |
+rxnMetaNetXID  |MetaNetX reaction ID    |
+rxnHMR2ID      |HMR2 reaction ID        |
+rxnRatconID    |Ratcon reaction ID      |
+rxnTCDBID      |TCDB ID                 |
+spontaneous    |Spontaneous status      |
+rxnMAID        |MA reaction ID          |
+rxnRheaID      |Rhea ID                 |
+rxnRheaMasterID|Master Rhea ID          |
+
+
+* `metabolites.tsv` content:
+
+fieldname      |  annotation             |
+---------------|-------------------------|
+mets           |identical to `model.mets`|
+metsNoComp     |`model.mets` without compartment suffix|
+metBiGGID      |BiGG metabolite ID       |
+metKEGGID      |KEGG metabolite ID       |
+metHMDBID      |HMDB ID                  |
+metChEBIID     |ChEBI ID                 |
+metPubChemID   |PubChem ID               |
+metLipidMapsID |LipidMaps ID             |
+metEHMNID      |EHMN metabolite ID       |
+metHepatoNET1ID|HepatoNET1 metabolite ID |
+metRecon3DID   |Recon3D metabolite ID    |
+metMetaNetXID  |MetaNetX metabolite ID   |
+metHMR2ID      |HMR2 metabolite ID       |
+metMAID        |MA metabolite ID         |
+
+
+* `genes.tsv` content:
+
+fieldname     |  annotation          |
+--------------|----------------------|
+genes         |Ensembl gene ID       |
+geneENSTID    |Ensembl transcript ID |
+geneENSPID    |Ensembl protein ID    |
+geneUniProtID |UniProt ID            |
+geneSymbols   |Gene Symbol           |
+geneEntrezID  |NCBI Entrez ID        |
+geneNames     |Gene Name             |
+geneAliases   |Alias Names           |
+
+
+To import/export this annotation data to/from MATLAB, use the `importTsvFile` and `exportTsvFile` functions, respectively.

--- a/model/README.md
+++ b/model/README.md
@@ -5,12 +5,12 @@ This directory contains the Human-GEM model and annotation files.
 
 ## Model
 
-The model is available as `.xml`, `.xlsx`, `.txt`, `.yml`, and `.mat` in the `model/` directory. Note that only the `.yml` version is available on branches other than `main` (e.g., `develop`), to facilitate tracking of model changes.
+The model is available as `.xml`, `.xlsx`, `.txt`, `.yml`, and `.mat`. Note that only the `.yml` version is available on branches other than `main` (e.g., `develop`), to facilitate tracking of model changes.
 
 
 ## Reaction, Metabolite, and Gene Annotations
 
-Additional annotation information and external identifiers for Human-GEM reactions, metabolites, and genes are provided as `tsv` files in the `model/` directory. The structure of the `tsv` files are tabulated below.
+Additional annotation information and external identifiers for Human-GEM reactions, metabolites, and genes are provided as `tsv` files. The structure of the `tsv` files are tabulated below.
 
 * `reactions.tsv` content:
 


### PR DESCRIPTION
### Main improvements in this PR:
* improve the `contributing guidelines` in Human-GEM
    * remove the section of git commands, which are no longer necessary after the implementation of yaml workflow
    * increase visibility of `contributing` section in README by moving it to top 
    * move annotation file details from main README to that under `model` directory

**I hereby confirm that I have:**

- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch

