### PR TITLE
see issues #328, adding CHEBI:53019 'glycan G00008' to MAM00154r

### DIFF
--- a/model/metabolites.tsv
+++ b/model/metabolites.tsv
@@ -325,7 +325,7 @@ mets	metsNoComp	metBiGGID	metKEGGID	metHMDBID	metChEBIID	metPubChemID	metLipidMa
 "MAM00152g"	"MAM00152"	"m7masnC"	""	""	""	""	""	""	""	"m7masnC"	"MNXM9454"	"m00152g"	"m00152g"
 "MAM00153g"	"MAM00153"	"m8masn"	""	""	""	""	""	""	""	"m8masn"	"MNXM6015"	"m00153g"	"m00153g"
 "MAM00153r"	"MAM00153"	"m8masn"	""	""	""	""	""	""	""	"m8masn"	"MNXM6015"	"m00153r"	"m00153r"
-"MAM00154r"	"MAM00154"	"g3m8mpdol__L"	"G00008"	""	""	""	""	""	""	"g3m8mpdol_L"	"MNXM147644"	"m00154r"	"m00154r"
+"MAM00154r"	"MAM00154"	""	"G00008"	""	"CHEBI:53019"	""	""	""	""	""	"MNXM147644"	"m00154r"	"m00154r"
 "MAM00155c"	"MAM00155"	""	"C02693"	""	""	""	""	""	""	"M00155"	"MNXM2239"	"m00155c"	"m00155c"
 "MAM00156c"	"MAM00156"	""	""	""	""	"53481438"	""	"CE2196"	""	"CE2196"	"MNXM31535"	"m00156c"	"m00156c"
 "MAM00157c"	"MAM00157"	"bhb"	"C01089"	"HMDB00011"	"CHEBI:17066"	"92135"	"LMFA01050005"	""	"HC00661"	"bhb"	"MNXM663"	"m00157c"	"m00157c"


### PR DESCRIPTION
MAM00154r is (Glc)3 (GlcNAc)2 (Man)9 (PP-Dol)1
and should have a xref to CHEBI:53019 (glycan G00008, synonym (Glc)3(GlcNAc)2(Man)9(PP-Dol)1 ).
And as far as I understand, BiGG g3m8mpdol__L is another compound: (alpha-D-Glucosyl)3-(alpha-D-mannosyl)8-beta-D-mannosyl-diacetylchitobiosyldiphosphodolichol, so I removed it.

**I hereby confirm that I have:**

- [ ] Tested my code on my own computer for running the model
- [x ] Selected `develop` as a target branch

*Note: replace [ ] with [X] to check the box. PLEASE DELETE THIS LINE*
