### PR TITLE
refactor: turn `importYaml` into a more generic function

### DIFF
--- a/code/GPRs/getGenesFromGrRules.m
+++ b/code/GPRs/getGenesFromGrRules.m
@@ -1,9 +1,9 @@
-function [genes,rxnGeneMat] = getGenesFromGrRules(grRules)
+function [genes,rxnGeneMat] = getGenesFromGrRules(grRules, originalGenes)
 %getGenesFromGrRules  Extract gene list and rxnGeneMat from grRules array.
 %
 % USAGE:
 %
-%   [genes,rxnGeneMat] = getGenesFromGrRules(grRules);
+%   [genes,rxnGeneMat] = getGenesFromGrRules(grRules, originalGenes);
 %
 % INPUTS:
 %
@@ -12,6 +12,7 @@ function [genes,rxnGeneMat] = getGenesFromGrRules(grRules)
 %               NOTE: Boolean operators can be text ("and", "or") or
 %                     symbolic ("&", "|"), but there must be a space
 %                     between operators and gene names/IDs.
+%   originalGenes     The original gene list from the model as reference
 %
 % OUTPUTS:
 %
@@ -23,6 +24,11 @@ function [genes,rxnGeneMat] = getGenesFromGrRules(grRules)
 %               genes.
 %
 
+
+% handle input arguments
+if nargin < 2
+    originalGenes = [];
+end
 
 % check if the grRules use written or symbolic boolean operators
 if any(contains(grRules,{'&','|'}))
@@ -49,6 +55,14 @@ rxnGenes = cellfun(@(r) unique(regexp(r,'[^&|\(\) ]+','match')),grRules,'Uniform
 % construct new gene list
 nonEmpty = ~cellfun(@isempty,rxnGenes);
 genes = unique([rxnGenes{nonEmpty}]');
+
+if ~isempty(originalGenes)
+    if ~isequal(sort(originalGenes), sort(genes))
+        error('The grRules and original gene list are inconsistent!');
+    else
+        genes = originalGenes;
+    end
+end
 
 % construct new rxnGeneMat (if requested)
 if nargout > 1

--- a/code/io/importYaml.m
+++ b/code/io/importYaml.m
@@ -86,7 +86,6 @@ while ~feof(fid)
             change_to_section = 2;
         case '- reactions:'
             change_to_section = 3;
-            readSubsystems = false;
             readEquation = false;
             rxnId = '';
         case '- genes:'
@@ -100,10 +99,21 @@ while ~feof(fid)
         if ~silentMode
             fprintf('\t%d\n', section);
         end
+        
+        if section == 4
+            readSubsystems = true;
+        else
+            readSubsystems = false;
+        end
+        
     end
 
     % skip over lines containing only omap
     if any(regexp(tline, "- !!omap"))
+        if readSubsystems
+            model.subSystems = [model.subSystems; {subSystems}];
+            readSubsystems = false;
+        end
         tline = fgetl(fid);
     end
     
@@ -197,7 +207,6 @@ while ~feof(fid)
             case 'confidence_score'
                 model = readFieldValue(model, 'rxnConfidenceScores', tline_value);
                 model.subSystems = [model.subSystems; {subSystems}];
-                readSubsystems = false;
 
             case 'metabolites'
                 readEquation = true;

--- a/code/io/importYaml.m
+++ b/code/io/importYaml.m
@@ -268,7 +268,7 @@ model.rxnConfidenceScores = str2double(model.rxnConfidenceScores);
 model.b = zeros(length(model.mets),1);
 model.c = double(ismember(model.rxns, objRxns));
 
-[genes, rxnGeneMat] = getGenesFromGrRules(model.grRules);
+[genes, rxnGeneMat] = getGenesFromGrRules(model.grRules, model.genes);
 if isequal(sort(genes), sort(model.genes))
     model.rxnGeneMat = rxnGeneMat;
     model.genes = genes;

--- a/code/io/importYaml.m
+++ b/code/io/importYaml.m
@@ -86,7 +86,6 @@ while ~feof(fid)
             change_to_section = 2;
         case '- reactions:'
             change_to_section = 3;
-            readEquation = false;
             rxnId = '';
         case '- genes:'
             change_to_section = 4;
@@ -206,7 +205,6 @@ while ~feof(fid)
 
             case 'confidence_score'
                 model = readFieldValue(model, 'rxnConfidenceScores', tline_value);
-                model.subSystems = [model.subSystems; {subSystems}];
 
             case 'metabolites'
                 readEquation = true;


### PR DESCRIPTION
### Main improvements in this PR:
* subsystem can be properly loaded regardless of the other reaction feature slots
* no longer sort gene list when importing Yaml file

**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch

