### PR TITLE
Fix: Amend #403 by merging additional model fields from duplicated rxns

### DIFF
--- a/code/modelCuration/removeDuplicateRxns_issue345.m
+++ b/code/modelCuration/removeDuplicateRxns_issue345.m
@@ -92,6 +92,19 @@ deprecRxnsTable = struct2table(deprecRxns);
 rxnAssocTable = struct2table(rxnAssoc);
 exportTsvFile([deprecRxnsTable; rxnAssocTable(rxn_indx(:,2), :)], depRxnFile);
 
+% merge additional model fields from duplicate rxns with the kept rxns
+mergeFields = {'eccodes'; 'rxnReferences'};
+for i = 1:size(rxns, 1)
+    for f = 1:numel(mergeFields)
+        entry1 = strsplit(model.(mergeFields{f}){rxn_indx(i,1)}, ';');
+        entry2 = strsplit(model.(mergeFields{f}){rxn_indx(i,2)}, ';');
+        merged_entry = setdiff(union(entry1, entry2), {''});
+        if ~isempty(merged_entry)
+            model.(mergeFields{f}){rxn_indx(i,1)} = strjoin(merged_entry, ';');
+        end
+    end
+end
+
 % delete reactions from model and annotation file
 model = removeReactions(model, rxns(:,2));
 exportYaml(model, '../../model/Human-GEM.yml');


### PR DESCRIPTION
### Main improvements in this PR:
Continues the work in #403 which addressed #345.

This PR merges information from the `eccodes` and `rxnReferences` model fields from the removed duplicate reactions with those of the retained reactions.

**Note:** I also inspected the `subSystems`, `rxnNames`, `rxnNotes`, and `rxnConfidenceScores` fields, but these were either identical or were not meaningful/appropriate to merge between the reaction pairs.

**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
