### PR TITLE
fix: remove some empty fields from imported yaml model

### DIFF
--- a/code/io/importYaml.m
+++ b/code/io/importYaml.m
@@ -303,6 +303,17 @@ equations(irrevInd) = strcat(leftEqns(irrevInd), ' =>', rightEqns(irrevInd));
 [~, metIdx] = ismember(model.mets, newMets);
 model.S = S(metIdx, :);
 
+% remove empty fields
+modelFields = fieldnames(model);
+emptyFields = modelFields(structfun(@isempty, model));
+keepFields = {'description', 'version'};  % some fields can be empty
+removeFields = setdiff(emptyFields, keepFields);
+model = rmfield(model, removeFields);
+if ~silentMode && (numel(removeFields) > 0)
+    fprintf('\nThe following empty fields were removed from the model:\n');
+    fprintf('\t%s\n', removeFields{:});
+end
+
 if ~silentMode
     fprintf(' Done!\n');
 end


### PR DESCRIPTION
### Main improvements in this PR:
The `importYaml` function defines and creates a set of model fields at the start of import, which means that if some fields are missing from the `.yml` file, the corresponding fields in the Matlab structure will be empty. Since some functions expect fields to be of a certain length (e.g., those relating to metabolites, genes, and reactions), empty fields may cause errors in those functions.

This PR implements a change in the `importYaml` function that checks if any model fields are still empty at the end of the import process, and removes those fields. A few exceptions are included to avoid removing some fields which are OK to be empty (`description`, `version`).

This PR also addresses an [Issue](https://github.com/SysBioChalmers/Mouse-GEM/issues/17) in the Mouse-GEM repository.

**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
