### PR TITLE
feat: prepHumanModelForftINIT with paths

### DIFF
--- a/code/tINIT/prepHumanModelForftINIT.m
+++ b/code/tINIT/prepHumanModelForftINIT.m
@@ -11,7 +11,7 @@ function prepDataHumanGEM = prepHumanModelForftINIT(model, convertGenes, essenti
 %   essentialTasksFilePath  [optional] Path to the metabolicTasks_Essential.txt
 %                           file. Default will use the file from Human-GEM, so
 %                           if using for example Mouse-GEM, supply another path.
-%   rxnsFilePath            [optional] Path to the rxns.tsv
+%   rxnsFilePath            Path to the reactions.tsv
 %                           file. Default will use the file from Human-GEM, so
 %                           if using for example Mouse-GEM, supply another path.
 %

--- a/code/tINIT/prepHumanModelForftINIT.m
+++ b/code/tINIT/prepHumanModelForftINIT.m
@@ -8,7 +8,7 @@ function prepDataHumanGEM = prepHumanModelForftINIT(model, convertGenes, essenti
 %                           such as Mouse-GEM.
 %   convertGenes            True if the genes should be converted to symbols 
 %                           ('CD8A' etc., and not ENSEMBL)
-%   essentialTasksFilePath  [optional] Path to the metabolicTasks_Essential.txt
+%   essentialTasksFilePath  Path to the metabolicTasks_Essential.txt
 %                           file. Default will use the file from Human-GEM, so
 %                           if using for example Mouse-GEM, supply another path.
 %   rxnsFilePath            Path to the reactions.tsv

--- a/code/tINIT/prepHumanModelForftINIT.m
+++ b/code/tINIT/prepHumanModelForftINIT.m
@@ -9,11 +9,13 @@ function prepDataHumanGEM = prepHumanModelForftINIT(model, convertGenes, essenti
 %   convertGenes            True if the genes should be converted to symbols 
 %                           ('CD8A' etc., and not ENSEMBL)
 %   essentialTasksFilePath  Path to the metabolicTasks_Essential.txt
-%                           file. Default will use the file from Human-GEM, so
-%                           if using for example Mouse-GEM, supply another path.
+%                           file. This file can normally be found under
+%                           HumanGEM/data/metabolicTasks/metabolicTasks_Essential.txt
+%                           If using for example Mouse-GEM, supply another path.
 %   rxnsFilePath            Path to the reactions.tsv
-%                           file. Default will use the file from Human-GEM, so
-%                           if using for example Mouse-GEM, supply another path.
+%                           file. This file can normally be found under
+%                           HumanGEM/model/reactions.tsv
+%                           If using for example Mouse-GEM, supply another path.
 %
 %   Usage: prepDataHumanGEM = prepHumanModelForftINIT(model, convertGenes, essentialTasksFilePath, rxnsFilePath)
 %

--- a/code/tINIT/prepHumanModelForftINIT.m
+++ b/code/tINIT/prepHumanModelForftINIT.m
@@ -1,22 +1,37 @@
-function prepDataHumanGEM = prepHumanModelForftINIT(model, convertGenes)
+function prepDataHumanGEM = prepHumanModelForftINIT(model, convertGenes, essentialTasksFilePath, rxnsFilePath)
 % prepHumanModelForftINIT
 %   Generates a "standard" prepData structure from Human-GEM to be used in ftINIT.
 %   This function typically takes a couple of hours to run, so we recommend to only 
 %   run this once and save the results to a .mat file.
 %
+%   model                   Either Human-GEM or a GEM derived from Human-GEM,
+%                           such as Mouse-GEM.
 %   convertGenes            True if the genes should be converted to symbols 
 %                           ('CD8A' etc., and not ENSEMBL)
+%   essentialTasksFilePath  [optional] Path to the metabolicTasks_Essential.txt
+%                           file. Default will use the file from Human-GEM, so
+%                           if using for example Mouse-GEM, supply another path.
+%   rxnsFilePath            [optional] Path to the rxns.tsv
+%                           file. Default will use the file from Human-GEM, so
+%                           if using for example Mouse-GEM, supply another path.
 %
-%   Usage: prepDataHumanGEM = prepHumanModelForftINIT(convertGenes)
+%   Usage: prepDataHumanGEM = prepHumanModelForftINIT(model, convertGenes, essentialTasksFilePath, rxnsFilePath)
 %
 
-
+if nargin < 4
+    [ST, I] = dbstack('-completenames');
+    path = fileparts(ST(I).file);
+    rxnsFilePath = fullfile(path,'..','..','model','reactions.tsv');
+    if nargin < 3
+        essentialTasksFilePath = fullfile(path,'..','..','data','metabolicTasks','metabolicTasks_Essential.txt');
+    end
+end
 
 
 %load tasks
-taskStruct = parseTaskList(which('metabolicTasks_Essential.txt'));
+taskStruct = parseTaskList(essentialTasksFilePath);
 %Spontaneous reactions:
-rxns_tsv = importTsvFile(which('reactions.tsv'));
+rxns_tsv = importTsvFile(rxnsFilePath);
 spont = rxns_tsv.spontaneous;
 spontRxnNames = rxns_tsv.rxns(spont == 1);%very few
 

--- a/code/tINIT/prepHumanModelForftINIT.m
+++ b/code/tINIT/prepHumanModelForftINIT.m
@@ -18,14 +18,6 @@ function prepDataHumanGEM = prepHumanModelForftINIT(model, convertGenes, essenti
 %   Usage: prepDataHumanGEM = prepHumanModelForftINIT(model, convertGenes, essentialTasksFilePath, rxnsFilePath)
 %
 
-if nargin < 4
-    [ST, I] = dbstack('-completenames');
-    path = fileparts(ST(I).file);
-    rxnsFilePath = fullfile(path,'..','..','model','reactions.tsv');
-    if nargin < 3
-        essentialTasksFilePath = fullfile(path,'..','..','data','metabolicTasks','metabolicTasks_Essential.txt');
-    end
-end
 
 
 %load tasks


### PR DESCRIPTION
This PR fixes issue #401 and now allows for specifying the paths to the tasks and reactions.tsv. This is good when using the code for for example Mouse-GEM.

### Main improvements in this PR:
prepHumanModelForftINIT supports other models such as Mouse-GEM - the paths to relevant files could not be specified earlier.

**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
