### PR TITLE
style: move from lab-based development to community curation

### DIFF
--- a/code/io/exportYaml.m
+++ b/code/io/exportYaml.m
@@ -248,9 +248,6 @@ fprintf(fid, ['    short_name: "', model.id, '"\n']);
 fprintf(fid, ['    full_name: "', model.description, '"\n']);
 fprintf(fid, ['    version: "', model.version, '"\n']);
 fprintf(fid, ['    date: "', datestr(now,29), '"\n']);  % 29=YYYY-MM-DD
-%fprintf(fid, ['    authors: "', model.annotation.authorList, '"\n']);
-%fprintf(fid, ['    email: "', model.annotation.email, '"\n']);
-%fprintf(fid, ['    organization: "', model.annotation.organization, '"\n']);
 fprintf(fid, ['    taxonomy: "', model.annotation.taxonomy, '"\n']);
 fprintf(fid, ['    github: "', model.annotation.sourceUrl, '"\n']);
 fprintf(fid, ['    description: "', model.annotation.note, '"\n']);

--- a/code/io/exportYaml.m
+++ b/code/io/exportYaml.m
@@ -248,9 +248,9 @@ fprintf(fid, ['    short_name: "', model.id, '"\n']);
 fprintf(fid, ['    full_name: "', model.description, '"\n']);
 fprintf(fid, ['    version: "', model.version, '"\n']);
 fprintf(fid, ['    date: "', datestr(now,29), '"\n']);  % 29=YYYY-MM-DD
-fprintf(fid, ['    authors: "', model.annotation.authorList, '"\n']);
-fprintf(fid, ['    email: "', model.annotation.email, '"\n']);
-fprintf(fid, ['    organization: "', model.annotation.organization, '"\n']);
+%fprintf(fid, ['    authors: "', model.annotation.authorList, '"\n']);
+%fprintf(fid, ['    email: "', model.annotation.email, '"\n']);
+%fprintf(fid, ['    organization: "', model.annotation.organization, '"\n']);
 fprintf(fid, ['    taxonomy: "', model.annotation.taxonomy, '"\n']);
 fprintf(fid, ['    github: "', model.annotation.sourceUrl, '"\n']);
 fprintf(fid, ['    description: "', model.annotation.note, '"\n']);

--- a/code/io/importYaml.m
+++ b/code/io/importYaml.m
@@ -150,12 +150,6 @@ for i=1:numel(line_key)
                 model.annotation.note = tline_value;
             case 'github'
                 model.annotation.sourceUrl = tline_value;
-            %case 'authors'
-            %    model.annotation.authorList = tline_value;
-            %case 'email'
-            %    model.annotation.email = tline_value;
-            %case 'organization'
-            %    model.annotation.organization = tline_value;
         end
     end
 

--- a/code/io/importYaml.m
+++ b/code/io/importYaml.m
@@ -150,12 +150,12 @@ for i=1:numel(line_key)
                 model.annotation.note = tline_value;
             case 'github'
                 model.annotation.sourceUrl = tline_value;
-            case 'authors'
-                model.annotation.authorList = tline_value;
-            case 'email'
-                model.annotation.email = tline_value;
-            case 'organization'
-                model.annotation.organization = tline_value;
+            %case 'authors'
+            %    model.annotation.authorList = tline_value;
+            %case 'email'
+            %    model.annotation.email = tline_value;
+            %case 'organization'
+            %    model.annotation.organization = tline_value;
         end
     end
 


### PR DESCRIPTION
#### Main improvements in this PR:
This PR aims to move forward to community curation
- ~~empty~~ remove `authors`, `email`, and `organization` fields in code and Yaml file
- use GitHub to count contributors 


**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
