### PR TITLE
fix: fatal importYaml bug

### DIFF
--- a/code/io/importYaml.m
+++ b/code/io/importYaml.m
@@ -276,7 +276,7 @@ if ~silentMode
     fprintf('\nimporting completed\nfollow-up processing...');
 end
 [~, model.metComps] = ismember(model.metComps, model.comps);
-model.metCharges = int64(str2double(model.metCharges));
+model.metCharges = str2double(model.metCharges);
 model.lb = str2double(model.lb);
 model.ub = str2double(model.ub);
 model.annotation.defaultLB = min(model.lb);

--- a/code/io/importYaml.m
+++ b/code/io/importYaml.m
@@ -28,14 +28,16 @@ end
 if verLessThan('matlab','9.9') %readlines introduced 2020b
     fid=fopen(yamlFilename);
     line_raw=cell(1000000,1);
+    i=1;
     while ~feof(fid)
         line_raw{i}=fgetl(fid);
         i=i+1;
     end
     line_raw(i:end)=[];
     line_raw=string(line_raw);
+    fclose(fid);
 else
-    line_raw=readlines(yamlFilename');
+    line_raw=readlines(yamlFilename);
 end
 
 line_key=regexprep(line_raw,'^ *-? ([^:]+)(:).*','$1');


### PR DESCRIPTION
#### Main improvements in this PR:
- fix:
  - `importYaml` fatal bug (solves #614)
  - `importYaml` makes `model.metCharges` as double, not int64 (see [RAVEN](https://github.com/SysBioChalmers/RAVEN/wiki/RAVEN-Model-Structure) and [COBRA](https://github.com/opencobra/cobratoolbox/blob/master/docs/source/notes/COBRAModelFields.md) model fields definitions)


**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [x] Tested my code on my own computer for running the model
- [x] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
