### PR TITLE
fix: refine animal GEM updating pipeline

### DIFF
--- a/code/addMetabolicNetwork.m
+++ b/code/addMetabolicNetwork.m
@@ -144,8 +144,11 @@ if any(ismember(newGenes, newModel.genes))
     newGenes = setdiff(newGenes, newModel.genes);
 end
 
-% append new genes to list of model genes
+% append new genes and their names to model
 newModel.genes = [newModel.genes; newGenes];
+emptyGeneNames = newGenes;
+emptyGeneNames(:) = {''};
+newModel.geneShortNames = [newModel.geneShortNames; emptyGeneNames];
 
 % add new columns to rxnGeneMat will be updated after the new reactions are added below.
 newModel.rxnGeneMat(:, end+1:end+numel(newGenes)) = 0;

--- a/code/updateAnimalGEM.m
+++ b/code/updateAnimalGEM.m
@@ -84,6 +84,7 @@ end
 
 %% Gap-filling
 [animalGEM, gapfillNetwork]=gapfill4EssentialTasks(animalGEM,ihuman,resetBiomass);
+animalGEM.b = animalGEM.b(:,1);   % ensure b field in single column
 
 
 %% post-gapfilling procedures

--- a/code/updateAnimalGEM.m
+++ b/code/updateAnimalGEM.m
@@ -1,4 +1,4 @@
-function [animalGEM, speciesSpecNetwork, gapfillNetwork]=updateAnimalGEM(orthologPairs,rxnsToAdd,metsToAdd,modelId)
+function [animalGEM, speciesSpecNetwork, gapfillNetwork]=updateAnimalGEM(orthologPairs,rxnsToAdd,metsToAdd,modelId,resetBiomass)
 % updateAnimalGEM
 %   Generate a model by using the Human-GEM as a template and taking into
 %   account species-specific pathways/reactions
@@ -11,7 +11,9 @@ function [animalGEM, speciesSpecNetwork, gapfillNetwork]=updateAnimalGEM(ortholo
 %   rxnsToAdd            the structure of species-specific reactions
 %   metsToAdd            the structure of species-specific metabolites
 %   modelId              model id
-%
+%   resetBiomass         reset biomass objective function to "biomass_componenets"
+%                        which is constituted by generic componenets that
+%                        suppose to occur in a eukaryotic cell (opt, default TRUE)
 %
 %   Output:
 %   animalGEM            an updated animal GEM
@@ -81,7 +83,7 @@ end
 
 
 %% Gap-filling
-[animalGEM, gapfillNetwork]=gapfill4EssentialTasks(animalGEM,ihuman);
+[animalGEM, gapfillNetwork]=gapfill4EssentialTasks(animalGEM,ihuman,resetBiomass);
 
 
 %% post-gapfilling procedures

--- a/code/updateAnimalGEM.m
+++ b/code/updateAnimalGEM.m
@@ -11,7 +11,7 @@ function [animalGEM, speciesSpecNetwork, gapfillNetwork]=updateAnimalGEM(ortholo
 %   rxnsToAdd            the structure of species-specific reactions
 %   metsToAdd            the structure of species-specific metabolites
 %   modelId              model id
-%   resetBiomass         reset biomass objective function to "biomass_componenets"
+%   resetBiomass         reset biomass objective function to "biomass_components"
 %                        which is constituted by generic componenets that
 %                        suppose to occur in a eukaryotic cell (opt, default TRUE)
 %


### PR DESCRIPTION
#### Main improvements in this PR:
This PR improves animal GEM updating pipeline:
  - sync `geneShortNames` field (introduced by #539) by padding with empty elements in function `addMetabolicNetwork`
  - enable `updateAnimalGEM` with option of reusing Human-GEM biomass equation


**I hereby confirm that I have:**
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
