### PR TITLE
fix: remove genes only expressed in peroxisome from beta-oxidation reactions in mitochondria

### DIFF
--- a/code/modelCuration/reportPeroxGenesFromBetaoxidationGPRsInMito.py
+++ b/code/modelCuration/reportPeroxGenesFromBetaoxidationGPRsInMito.py
@@ -1,0 +1,26 @@
+# 1. read gene compartment from genes.tsv and load model
+# 2. get the reactions in fatty acid oxidation subsystem and mitochondria compartment
+# 3. go through the reactions and check the compartment of each genes in the GPR
+# 4. report the genes that are only expressed in peroxisome
+import csv
+import cobra
+import pandas as pd
+
+# load genes.tsv and read info into a dict for genes and their compartments
+with open("../../model/genes.tsv", 'r') as file:
+    reader = csv.reader(file, delimiter='\t')
+    geneCompDict = {row[0]: row[8] for row in reader}
+
+# load model
+model = cobra.io.load_yaml_model('../../model/Human-GEM.yml')
+
+# collect reactions from "Fatty acid oxidation" subsystem and in [m] compartment
+subsys = 'Fatty acid oxidation'
+targetComp = {'m'}
+for r in model.reactions:
+    if subsys in r.subsystem and targetComp == r.compartments:
+        # go through collected reactions find genes that exist only in peroxisome
+        for g in r.genes:
+            if geneCompDict[g.id] == 'Peroxisome':
+                print(f'{r.id} | {g.id} | {r.build_reaction_string(True)} | {r.gene_reaction_rule} | {r.gene_name_reaction_rule}')
+


### PR DESCRIPTION
#### Main improvements in this PR:
<!-- Try to be as clear as possible in providing a summary of the work and reference the corresponding issue.
Is it fixing/adding something in the model?
Is it an additional test/function/dataset? 
-->

according to the table reported by #767, this PR remove genes expressed only in peroxisome from GPRs of beta-oxidation reactions in mitochondria. The specific changes are:
- add [code](https://github.com/SysBioChalmers/Human-GEM/pull/770/files#diff-186bf4f9b5d35a79293ff1230e7cd76d9a16b2fcb2bd2dad9e1cabe2557dac1f), which is inspired by #746, for checking genes with mismatched compartment assignment
- remove ENSG00000115425 from MAR02028, MAR02148, MAR02149, MAR02183, MAR02187, MAR02207, respectively
- remove ENSG00000113790 from MAR03297, MAR03374, MAR03378, MAR03379, respectively
- remove ENSG00000060971 from MAR02381 and modify the GPR to `ENSG00000138029 or ENSG00000167315`, as reported in #759

Note that modifications to MAR03269 and MAR03380 had already been addressed by #760

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [X] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
