### PR TITLE
feat: PR template mentions merge type

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,9 +5,9 @@ Is it an additional test/function/dataset?
 e.g. This PR improves/fixes # by ...
 -->
 
-
 **I hereby confirm that I have:**
 <!-- *Note: replace [ ] with [X] to check the box. -->
-- [ ] Tested my code on my own computer for running the model
-- [ ] Selected `develop` as a target branch
 - [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
+<!-- Chose ONE of the following two options. -->
+- [ ] This PR has `develop` as target branch, and will be resolved with a **squash-merge**.
+- [ ] This PR has `main` as target branch, and will be resolved with a **merge commit**.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ e.g. This PR improves/fixes # by ...
 
 **I hereby confirm that I have:**
 <!-- *Note: replace [ ] with [X] to check the box. -->
-- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
+- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists in `data/deprecatedIdentifiers/`.
 <!-- Chose ONE of the following two options. -->
 - [ ] This PR has `develop` as target branch, and will be resolved with a **squash-merge**.
 - [ ] This PR has `main` as target branch, and will be resolved with a **merge commit**.


### PR DESCRIPTION
#### Main improvements in this PR:
The PR template now clarifies that *squash-merge* should be used for merges to `develop`, while merges to `main` should be resolved as *merge commit*. The checkboxes help to remember this, but the actual choice of merge type can only be selected when the actual merge is made. The reason for using *squash-merge* to `develop` is to somewhat reduce the clutter in the repository's git history.

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists in `data/deprecatedIdentifiers/`.
<!-- Chose ONE of the following two options. -->
- [X] This PR has `develop` as target branch, and will be resolved with a **squash-merge**.
- [ ] This PR has `main` as target branch, and will be resolved with a **merge commit**.
