### PR TITLE
fix: allow macaw and gene essentiality to run simultaneously

### DIFF
--- a/data/testResults/README.md
+++ b/data/testResults/README.md
@@ -2,7 +2,12 @@
 
 The file here contains results from the [MACAW](https://github.com/Devlin-Moyer/macaw) `dead_end_test` and `duplicate_test` tests, and from cell-line specific gene essentiality prediction based on the [Hart _et al._ (2015)](https://doi.org/10.1016/j.cell.2015.11.015) dataset.
 
-The test results shown here were obtained by the GitHub Actions run in **PR #882** (MACAW) and **PR #675** (gene essentiality), and will be updated by any subsequent PR. Summary results are shown as a comment in the corresponding PR.
+The test results shown here were obtained by the GitHub Actions run in:
+
+- **PR #882** (MACAW)
+- **PR #675** (gene essentiality)
+
+The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.
 
 ### MACAW: `dead_end_test`
 Looks for metabolites in Human-GEM that can only be produced by all reactions they participate in or only consumed, then identifies all reactions that are prevented from sustaining steady-state fluxes because of each of these dead-end metabolites. The simplest case of a dead-end metabolite is one that only participates in a single reaction. Also flags all reversible reactions that can only carry fluxes in a single direction because one of their metabolites can either only be consumed or only be produced by all other reactions it participates in.

--- a/data/testResults/README.md
+++ b/data/testResults/README.md
@@ -4,7 +4,7 @@ The file here contains results from the [MACAW](https://github.com/Devlin-Moyer/
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #882** (MACAW)
+- **PR #906** (MACAW)
 - **PR #675** (gene essentiality)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:
Both the MACAW and gene essentiality tests commit the PR number in `data/testResults/README.md`, but this will cause conflicts if they are mentioned in the same line.


**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [X] Tested my code on my own computer for running the model
- [x] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
