### PR TITLE
fix-GPR curation for Xenobiotics metabolism

### DIFF
--- a/data/testResults/README.md
+++ b/data/testResults/README.md
@@ -2,7 +2,7 @@
 
 The file here contains results from the [MACAW](https://github.com/Devlin-Moyer/macaw) `dead_end_test` and `duplicate_test` tests, and from cell-line specific gene essentiality prediction based on the [Hart _et al._ (2015)](https://doi.org/10.1016/j.cell.2015.11.015) dataset.
 
-The test results shown here were obtained by the GitHub Actions run in **PR #882** (MACAW) and **PR #675** (gene essentiality), and will be updated by any subsequent PR. Summary results are shown as a comment in the corresponding PR.
+The test results shown here were obtained by the GitHub Actions run in **PR #913** (MACAW) and **PR #675** (gene essentiality), and will be updated by any subsequent PR. Summary results are shown as a comment in the corresponding PR.
 
 ### MACAW: `dead_end_test`
 Looks for metabolites in Human-GEM that can only be produced by all reactions they participate in or only consumed, then identifies all reactions that are prevented from sustaining steady-state fluxes because of each of these dead-end metabolites. The simplest case of a dead-end metabolite is one that only participates in a single reaction. Also flags all reversible reactions that can only carry fluxes in a single direction because one of their metabolites can either only be consumed or only be produced by all other reactions it participates in.


### PR DESCRIPTION
#### Main improvements in this PR:
<!-- Try to be as clear as possible in providing a summary of the work and reference the corresponding issue.
Is it fixing/adding something in the model?
Is it an additional test/function/dataset? 
e.g. This PR improves/fixes # by ...
-->
As proposed in #864 
- Remove `ENSG00000147576`, `ENSG00000196616` from MAR07038;
- Remove `ENSG00000108242` from MAR07053;
- Remove `ENSG00000117594` from MAR07059;
- Remove `ENSG00000108242` from MAR07096;
- Remove `ENSG00000117592` from MAR06536;
- Remove `ENSG00000184254`, `ENSG00000006534` from MAR09569;
- Remove `ENSG00000130508` from MAR06535;
- Remove `ENSG00000108242` from MAR07019;
- Remove `ENSG00000108242` from MAR07021;
- Remove `ENSG00000186377`, `ENSG00000137869` from MAR04019;
- Remove `ENSG00000186160`, `ENSG00000186377` from MAR04041;
- Remove `ENSG00000108242` from MAR04051.


**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
