### PR TITLE
Fix: GPR curation for Sulfur metabolism

### DIFF
--- a/data/testResults/README.md
+++ b/data/testResults/README.md
@@ -2,7 +2,7 @@
 
 The file here contains results from the [MACAW](https://github.com/Devlin-Moyer/macaw) `dead_end_test` and `duplicate_test` tests, and from cell-line specific gene essentiality prediction based on the [Hart _et al._ (2015)](https://doi.org/10.1016/j.cell.2015.11.015) dataset.
 
-The test results shown here were obtained by the GitHub Actions run in **PR #913** (MACAW) and **PR #675** (gene essentiality), and will be updated by any subsequent PR. Summary results are shown as a comment in the corresponding PR.
+The test results shown here were obtained by the GitHub Actions run in **PR #937** (MACAW) and **PR #675** (gene essentiality), and will be updated by any subsequent PR. Summary results are shown as a comment in the corresponding PR.
 
 ### MACAW: `dead_end_test`
 Looks for metabolites in Human-GEM that can only be produced by all reactions they participate in or only consumed, then identifies all reactions that are prevented from sustaining steady-state fluxes because of each of these dead-end metabolites. The simplest case of a dead-end metabolite is one that only participates in a single reaction. Also flags all reversible reactions that can only carry fluxes in a single direction because one of their metabolites can either only be consumed or only be produced by all other reactions it participates in.


### PR DESCRIPTION
#### Main improvements in this PR:
As proposed in #892 
- Remove `ENSG00000104331` from MAR04187;
- Remove `ENSG00000108602` from MAR04842;
- Remove `ENSG00000204386` from MAR07530;
- Remove `ENSG00000204386` from MAR07542;
- Remove `ENSG00000204386` from MAR07560;
- Remove `ENSG00000204386` from MAR07526;
- Remove `ENSG00000204386` from MAR07547;
- Remove `ENSG00000135702` from MAR07369;
- Remove `ENSG00000106304` from MAR07503.


**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
