### PR TITLE
Remove peroxisomal genes from mitochondrial ACAD reactions

### DIFF
--- a/model/Human-GEM.yml
+++ b/model/Human-GEM.yml
@@ -62692,7 +62692,7 @@
           - MAM02774m: -1
       - lower_bound: 0
       - upper_bound: 1000
-      - gene_reaction_rule: "ENSG00000117054 or ENSG00000122971 or ENSG00000151498 or ENSG00000177646 or ENSG00000196177 or ENSG00000240303"
+      - gene_reaction_rule: "ENSG00000122971 or ENSG00000151498 or ENSG00000196177"
       - rxnFrom: "HMRdatabase"
       - eccodes:
           - "1.3.99.3"
@@ -63045,7 +63045,7 @@
           - MAM01803m: 1
       - lower_bound: 0
       - upper_bound: 1000
-      - gene_reaction_rule: "ENSG00000117054 or ENSG00000122971 or ENSG00000151498 or ENSG00000177646 or ENSG00000196177 or ENSG00000240303"
+      - gene_reaction_rule: "ENSG00000122971 or ENSG00000151498 or ENSG00000196177"
       - rxnFrom: "HMRdatabase"
       - eccodes: "1.3.99.3"
       - references: "PMID:13295225;PMID:3597357"
@@ -96078,7 +96078,7 @@
           - MAM02630m: -1
       - lower_bound: 0
       - upper_bound: 1000
-      - gene_reaction_rule: "ENSG00000087008 or ENSG00000161533"
+      - gene_reaction_rule: "ENSG00000072778 or ENSG00000115361 or ENSG00000177646"
       - rxnFrom: "HMRdatabase"
       - eccodes: "1.3.3.6"
       - references: "PMID:12054595"
@@ -96318,7 +96318,7 @@
           - MAM02630m: -1
       - lower_bound: 0
       - upper_bound: 1000
-      - gene_reaction_rule: "ENSG00000087008 or ENSG00000161533"
+      - gene_reaction_rule: "ENSG00000072778 or ENSG00000115361 or ENSG00000177646"
       - rxnFrom: "HMRdatabase"
       - eccodes: "1.3.3.6"
       - references: "PMID:11368003;PMID:9862787"
@@ -200344,7 +200344,7 @@
           - MAM03333m: -1
       - lower_bound: -1000
       - upper_bound: 1000
-      - gene_reaction_rule: "ENSG00000115361 or ENSG00000117054 or ENSG00000196177"
+      - gene_reaction_rule: "ENSG00000115361"
       - rxnFrom: "Recon3D"
       - eccodes: "1.3.99.3"
       - references: "PMID:1047780;PMID:11135616;PMID:8973539"
@@ -203468,7 +203468,7 @@
           - MAM03352m: -1
       - lower_bound: 0
       - upper_bound: 1000
-      - gene_reaction_rule: "ENSG00000161533"
+      - gene_reaction_rule: "ENSG00000072778 or ENSG00000115361"
       - rxnFrom: "Recon3D"
       - eccodes: "1.3.3.6"
       - references: "PMID:11356164;PMID:7775433"


### PR DESCRIPTION
#### Main improvements in this PR:

As proposed in #634:
- Sets the GPRs of `MAR01253` and `MAR01270` to `ENSG00000072778 or ENSG00000115361 or ENSG00000177646`
- Sets the GPR of `MAR03997` to `ENSG00000072778 or ENSG00000115361`
- Sets the GPR of `MAR03291` to `ENSG00000115361`
- Sets the GPRs of `MAR03163` and `MAR03212` to `ENSG00000122971 or ENSG00000151498 or ENSG00000196177`

**I hereby confirm that I have:**
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [X] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
