### PR TITLE
Fix: GPR curation for Sphingolipid metabolism

### DIFF
--- a/data/testResults/README.md
+++ b/data/testResults/README.md
@@ -4,7 +4,7 @@ The file here contains results from the [MACAW](https://github.com/Devlin-Moyer/
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #830** (MACAW)
+- **PR #946** (MACAW)
 - **PR #883** (gene essentiality)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:
As proposed in #860 
- Remove `ENSG00000101577`, `ENSG00000132793`, `ENSG00000134324` from MAR00746;
- Remove `ENSG00000102595`, `ENSG00000175711`, `ENSG00000147162`, `ENSG00000180549`, `ENSG00000069943`, `ENSG00000172461`, `ENSG00000198488`, `ENSG00000170340`, `ENSG00000196371`, `ENSG00000136731`, `ENSG00000172728`, `ENSG00000085998`, `ENSG00000167889` from MAR00765;
- Remove `ENSG00000101577` from MAR00767;
- Remove `ENSG00000134324` from MAR00775;
- Remove `ENSG00000179913` from MAR08152;
- Remove `ENSG00000179913` from MAR08173;
- Remove `ENSG00000179913` from MAR08249.


**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
