### PR TITLE
Fix: GPR curation for Estrogen and Steroid metabolism

### DIFF
--- a/data/testResults/README.md
+++ b/data/testResults/README.md
@@ -4,7 +4,7 @@ The file here contains results from the [MACAW](https://github.com/Devlin-Moyer/
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #830** (MACAW)
+- **PR #948** (MACAW)
 - **PR #883** (gene essentiality)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.


### PR DESCRIPTION
#### Main improvements in this PR:
As proposed in #851 :
- Change the GPR of MAR01927 as `ENSG00000140459 or ENSG00000138061`, and add `PMID:39395524` as additional references;
- Change the GPR of MAR02029 as `ENSG00000137869`, and add `PMID:34095690` as additional references;
- Change the GPR of MAR02030 as `ENSG00000137869`, and add `PMID:34095690` as additional references;
- Change the GPR of MAR02031 as `ENSG00000137869`, and add `PMID:34095690` as additional references;
- Change the GPR of MAR02032 as `ENSG00000137869`, and add `PMID:34095690` as additional references;
- Change the GPR of MAR02033 as `ENSG00000137869`, and add `PMID:34095690` as additional references;
- Change the GPR of MAR02034 as `ENSG00000137869`, and add `PMID:34095690` as additional references;
- Change the GPR of MAR02038 as `ENSG00000101846`, and add `PMID:37951289` as additional references;
- Change the GPR of MAR07940 as `ENSG00000137869`, and add `PMID:34095690` as additional references;
- Change the GPR of MAR07941 as `ENSG00000137869`, and add `PMID:34095690` as additional references;
- Change the GPR of MAR07957 as `ENSG00000137869`, and add `PMID:34095690` as additional references;
- Remove `ENSG00000155016`, `ENSG00000186377`, `ENSG00000186526` from MAR02042;
- Remove `ENSG00000108242`, `ENSG00000134716`, `ENSG00000186377` from MAR02043;
- Remove `ENSG00000186377`, `ENSG00000186160`, `ENSG00000186204`, `ENSG00000108242` from MAR02053;
- Remove `ENSG00000186204`, `ENSG00000155016`, `ENSG00000186377`, `ENSG00000186526` from MAR02054;
- Remove `ENSG00000115705` from MAR02077;
- Remove `ENSG00000115705` from MAR02089;
- Remove `ENSG00000137869` from MAR02458, MAR00947, MAR01156, MAR01155, MAR04051, MAR00994, MAR01196, MAR04055, MAR00950, MAR01154, MAR00955, MAR00942, MAR01149, MAR00931, MAR00954, MAR00937, MAR00935, MAR06658, MAR04090, MAR00951, MAR02457, MAR01150, MAR01193, MAR00992, MAR00938, MAR02456, MAR01152, MAR03788, MAR01195, MAR00934, MAR00936, MAR00991, MAR00948, MAR00993, MAR02455, MAR01194, MAR00933, MAR00944, MAR00940, MAR00943, MAR04041, MAR00939, MAR00946, MAR00956, MAR01151, MAR01153, MAR00932.



**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
