### PR TITLE
Fix: updated lower bound of MAR04356 to make it reversible

### DIFF
--- a/model/Human-GEM.yml
+++ b/model/Human-GEM.yml
@@ -61605,7 +61605,7 @@
           - MAM01690c: -1
           - MAM01842c: 1
           - MAM01981c: -1
-      - lower_bound: 0
+      - lower_bound: -1000
       - upper_bound: 1000
       - gene_reaction_rule: "ENSG00000109107 or ENSG00000136872 or ENSG00000149925"
       - rxnFrom: "HMRdatabase"


### PR DESCRIPTION
#### Main improvements in this PR:
This change fixes #990 by changing the lower bounds of reaction MAR04356 to -1000 in the model .yml file, thereby making the reaction reversible. This matches the real biology as highlighted in the issue.

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [X] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
