### PR TITLE
fix: read spontaneous column as numeric in prepHumanModelForftINIT

### DIFF
--- a/code/tINIT/prepHumanModelForftINIT.m
+++ b/code/tINIT/prepHumanModelForftINIT.m
@@ -27,6 +27,11 @@ taskStruct = parseTaskList(essentialTasksFilePath);
 %Spontaneous reactions:
 rxns_tsv = importTsvFile(rxnsFilePath);
 spont = rxns_tsv.spontaneous;
+% importTsvFile returns this column as text when reactions.tsv has no quoted
+% fields (as in Human-GEM v2.0.0 and later), so coerce to numeric (see #1020)
+if iscell(spont)
+    spont = str2double(spont);
+end
 spontRxnNames = rxns_tsv.rxns(spont == 1);%very few
 
 %remove some reactions often not used from the model to speed up calculations


### PR DESCRIPTION
#### Main improvements in this PR:
As reported in #1020, `prepHumanModelForftINIT` fails on Human-GEM v2.0.0 at `spont == 1` with "Operator '==' is not supported for operands of type cell".

From v2.0.0 the reactions.tsv is written without quoted fields, so `importTsvFile` returns the `spontaneous` column as text rather than numeric (in v1.x the file was quoted, so it was read as numeric).

- Coerce the `spontaneous` column to numeric in `prepHumanModelForftINIT` when it is returned as text, so the function works regardless of how reactions.tsv is quoted.

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [X] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
