### PR TITLE
fix: merge duplicate pentose phosphate pathway subsystem

### DIFF
--- a/model/Human-GEM.yml
+++ b/model/Human-GEM.yml
@@ -244277,7 +244277,7 @@
       - upper_bound: 1000
       - eccodes: "3.1.3.11"
       - references: "PMID:6998788"
-      - subsystem: "Pentose Phosphate Pathway"
+      - subsystem: "Pentose phosphate pathway"
       - confidence_score: 0
       - rxnNotes: "https://doi.org/10.1007/BF02702726"
     - !!omap


### PR DESCRIPTION
#### Main improvements in this PR:
As reported in #1003, the pentose phosphate pathway appears as two subsystems: MAR20070 has its subsystem set to "Pentose Phosphate Pathway" (title case), while the other 25 reactions of the pathway use "Pentose phosphate pathway". The wrong casing was introduced when MAR20070 was added in #551.

- Correct the subsystem of MAR20070 to "Pentose phosphate pathway", merging the two groups into one.

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [X] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
