### PR TITLE
fix: remove LDHAL6A from MAR11479 for GPR consistency with MAR11476

### DIFF
--- a/data/testResults/README.md
+++ b/data/testResults/README.md
@@ -4,7 +4,7 @@ The file here contains results from the [MACAW](https://github.com/Devlin-Moyer/
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #1029** (MACAW)
+- **PR #1038** (MACAW)
 - **PR #973** (gene essentiality)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.

--- a/model/Human-GEM.yml
+++ b/model/Human-GEM.yml
@@ -220025,7 +220025,7 @@
           - MAM03186c: 1
       - lower_bound: -1000
       - upper_bound: 1000
-      - gene_reaction_rule: "ENSG00000111716 or ENSG00000134333 or ENSG00000166796 or ENSG00000166800 or ENSG00000166816 or ENSG00000171989"
+      - gene_reaction_rule: "ENSG00000111716 or ENSG00000134333 or ENSG00000166796 or ENSG00000166816 or ENSG00000171989"
       - rxnFrom: "Recon3D"
       - eccodes: "1.1.1.27"
       - references: "PMID:1429566"


### PR DESCRIPTION
#### Main improvements in this PR:
Found while reviewing #528. MAR11476 and MAR11479 are the same promiscuous lactate dehydrogenase side-reaction on adjacent branched-chain 2-oxo acids. The GPR curation in #847 / #885 removed LDHAL6A (`ENSG00000166800`) from MAR11476 as not relevant to the reaction, but left it on the identical MAR11479.

- Remove LDHAL6A (`ENSG00000166800`) from the GPR of MAR11479, so it matches MAR11476 (LDHB, LDHA, LDHC, LDHD, LDHAL6B).

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [X] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
