### PR TITLE
Add citation.cff with the published Human2 (PNAS) citation

### DIFF
--- a/citation.cff
+++ b/citation.cff
@@ -1,0 +1,64 @@
+cff-version: 1.2.0
+message: "If you use human-GEM, please cite the article as below."
+title: "Human-GEM"
+authors:
+  - family-names: "Luo"
+    given-names: "Jiahao"
+  - family-names: "Wang"
+    given-names: "Hao"
+  - family-names: "Moyer"
+    given-names: "Devlin"
+  - family-names: "Guo"
+    given-names: "Zhetao"
+  - family-names: "Robinson"
+    given-names: "Jonathan L."
+  - family-names: "Gustafsson"
+    given-names: "Johan"
+  - family-names: "Anton"
+    given-names: "Mihail"
+  - family-names: "Chen"
+    given-names: "Yu"
+  - family-names: "Kerkhoven"
+    given-names: "Eduard J."
+  - family-names: "Nielsen"
+    given-names: "Jens"
+  - family-names: "Li"
+    given-names: "Feiran"
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.4099692
+repository-code: 'https://github.com/SysBioChalmers/Human-GEM'
+version: 2.0.0
+date-released: 2026-03-30
+preferred-citation:
+  type: article
+  authors:
+    - family-names: "Luo"
+      given-names: "Jiahao"
+    - family-names: "Wang"
+      given-names: "Hao"
+    - family-names: "Moyer"
+      given-names: "Devlin"
+    - family-names: "Guo"
+      given-names: "Zhetao"
+    - family-names: "Robinson"
+      given-names: "Jonathan L."
+    - family-names: "Gustafsson"
+      given-names: "Johan"
+    - family-names: "Anton"
+      given-names: "Mihail"
+    - family-names: "Chen"
+      given-names: "Yu"
+    - family-names: "Kerkhoven"
+      given-names: "Eduard J."
+    - family-names: "Nielsen"
+      given-names: "Jens"
+    - family-names: "Li"
+      given-names: "Feiran"
+  doi: "10.1073/pnas.2516511123"
+  journal: "Proceedings of the National Academy of Sciences"
+  title: "Reconstruction of human metabolic models with large language models"
+  volume: 123
+  issue: 15
+  year: 2026
+  start: "e2516511123"


### PR DESCRIPTION
#### Main improvements in this PR:
`citation.cff` was added to `main` with 2.0.0 (#303), but it is missing on `develop`, and its `preferred-citation` still lists the Human2 article as "in press" with an empty DOI. The article is now published, so this brings `citation.cff` onto `develop` with the final reference.

- Add `citation.cff` so GitHub's "Cite this repository" feature works.
- Point the preferred citation to the published Human2 article: Luo et al., _Proc. Natl. Acad. Sci._ 123, e2516511123 (2026), [doi:10.1073/pnas.2516511123](https://doi.org/10.1073/pnas.2516511123).

The README citation on `develop` already references this article, so the two now match. When `develop` next flows to `main`, the live "Cite this repository" entry updates from "in press" to the published reference.

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [X] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
