### PR TITLE
fix: update ferrochelatase (FECH) EC number to 4.98.1.1

### DIFF
--- a/data/testResults/README.md
+++ b/data/testResults/README.md
@@ -4,7 +4,7 @@ The file here contains results from the [MACAW](https://github.com/Devlin-Moyer/
 
 The test results shown here were obtained by the GitHub Actions run in:
 
-- **PR #1035** (QC)
+- **PR #1048** (QC)
 - **PR #973** (gene essentiality)
 
 The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.

--- a/model/Human-GEM.yml
+++ b/model/Human-GEM.yml
@@ -182088,7 +182088,7 @@
       - upper_bound: 1000
       - gene_reaction_rule: "ENSG00000066926"
       - rxnFrom: "Recon3D"
-      - eccodes: "4.99.1.1"
+      - eccodes: "4.98.1.1"
       - references: "PMID:7983009;PMID:11175906;PMID:11215517;PMID:11853551;PMID:11947230;PMID:1624416;PMID:182145;PMID:2310748;PMID:3196293;PMID:3702737;PMID:406931;PMID:6425295;PMID:7309736;PMID:8818224;PMID:9712849;PMID:9808757"
       - subsystem: "Porphyrin metabolism"
       - confidence_score: 0


### PR DESCRIPTION
#### Main improvements in this PR:
Resolves #366. Ferrochelatase (FECH) was reclassified in the IUBMB Enzyme nomenclature: EC 4.99.1.1 is now a transferred entry pointing to EC 4.98.1.1 (protoporphyrin ferrochelatase), part of the new sub-class 4.98 for enzymes that form carbon-metal bonds.

- Update `MAR01044` (Ferrochelatase, Mitochondrial) `eccodes` from `4.99.1.1` to `4.98.1.1`.

The old code is a deleted entry and is replaced rather than kept, to avoid a dead lookup for EC-based tools such as GECKO. Verified against the ExPASy ENZYME database.

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [X] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists
